### PR TITLE
fix: enable Sentry error reporting in production builds

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -48,6 +48,13 @@ export default {
     plugins: [
       "expo-updates",
       "expo-audio",
+      [
+        "@sentry/react-native/expo",
+        {
+          organization: process.env.SENTRY_ORG,
+          project: process.env.SENTRY_PROJECT,
+        },
+      ],
       // Configuración de AdMob (como array separado)
       [
         "react-native-google-mobile-ads",

--- a/eas.json
+++ b/eas.json
@@ -2,19 +2,43 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "DSN_SENTRY": "$DSN_SENTRY",
+        "SENTRY_AUTH_TOKEN": "$SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG": "$SENTRY_ORG",
+        "SENTRY_PROJECT": "$SENTRY_PROJECT"
+      }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "DSN_SENTRY": "$DSN_SENTRY",
+        "SENTRY_AUTH_TOKEN": "$SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG": "$SENTRY_ORG",
+        "SENTRY_PROJECT": "$SENTRY_PROJECT"
+      }
     },
     "preview2": {
       "android": {
         "buildType": "apk"
+      },
+      "env": {
+        "DSN_SENTRY": "$DSN_SENTRY",
+        "SENTRY_AUTH_TOKEN": "$SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG": "$SENTRY_ORG",
+        "SENTRY_PROJECT": "$SENTRY_PROJECT"
       }
     },
     "production": {
       "android": {
         "buildType": "app-bundle"
+      },
+      "env": {
+        "DSN_SENTRY": "$DSN_SENTRY",
+        "SENTRY_AUTH_TOKEN": "$SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG": "$SENTRY_ORG",
+        "SENTRY_PROJECT": "$SENTRY_PROJECT"
       }
     }
   },


### PR DESCRIPTION
## Problema

Sentry solo capturaba errores en modo desarrollo. En builds de producción los errores no llegaban porque:

1. **Faltaba el plugin `@sentry/react-native/expo`** — sin él, los source maps no se suben a Sentry durante el build de EAS y los stack traces llegan completamente ilegibles (código minificado)
2. **`eas.json` no pasaba las variables de entorno** a los builds de EAS — en producción `DSN_SENTRY` era `undefined` y `Sentry.init()` no inicializaba nada

## Cambios

- **`app.config.js`**: agregado plugin `@sentry/react-native/expo` con `SENTRY_ORG` y `SENTRY_PROJECT`
- **`eas.json`**: agregado bloque `env` en todos los perfiles (`development`, `preview`, `preview2`, `production`) con las 4 variables de Sentry

## Pendiente antes de hacer merge

Agregar las siguientes variables como **EAS Secrets** en [expo.dev](https://expo.dev) → tu proyecto → Secrets:

| Variable | Valor |
|---|---|
| `DSN_SENTRY` | El DSN de tu proyecto en Sentry |
| `SENTRY_AUTH_TOKEN` | El auth token de Sentry |
| `SENTRY_ORG` | `zuve` |
| `SENTRY_PROJECT` | El slug de tu proyecto en Sentry (verificar en sentry.io) |

## Test plan

- [ ] Hacer un build de producción con EAS y verificar que los source maps se suben correctamente en el dashboard de Sentry
- [ ] Provocar un error intencionalmente en producción y confirmar que llega a Sentry con stack trace legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)