### PR TITLE
feat: optimize question files and add 20 new verdad questions

### DIFF
--- a/src/data/retos/amigos-reto.json
+++ b/src/data/retos/amigos-reto.json
@@ -1,178 +1,62 @@
 [
-  {
-    "id": 1,
-    "text": "Imita al amigo del grupo que más exagera al contar historias."
-  },
-  {
-    "id": 2,
-    "text": "Deja que el grupo elija una foto de tu galería para verla durante 8 segundos."
-  },
-  {
-    "id": 3,
-    "text": "Envía un audio cantando como ópera a un contacto aleatorio."
-  },
-  {
-    "id": 4,
-    "text": "Haz 15 sentadillas narrando lo que haces como si fuera un documental épico."
-  },
-  {
-    "id": 5,
-    "text": "Publica en tu estado: 'Acepto teorías conspirativas, inbox abierto'."
-  },
-  {
-    "id": 6,
-    "text": "Baila 30 segundos como si la música fuera increíble… aunque no haya música."
-  },
-  { "id": 7, "text": "Habla 1 minuto sin usar las palabras: yo, sí, no." },
-  {
-    "id": 8,
-    "text": "Canta el coro de una canción famosa usando solo tarareos dramáticos."
-  },
-  {
-    "id": 9,
-    "text": "Graba un TikTok actuando como si fueras famoso y nadie te reconociera."
-  },
-  {
-    "id": 10,
-    "text": "Desfila como modelo, pero cada 5 segundos cambia de emoción exageradamente."
-  },
-
-  {
-    "id": 11,
-    "text": "Envía un mensaje: 'Tenemos que hablar… luego te explico' y no respondas por 10 minutos."
-  },
-  {
-    "id": 12,
-    "text": "Vende un objeto común como si costara millones (el grupo decide si lo compra)."
-  },
-  {
-    "id": 13,
-    "text": "Cuenta una historia real… pero agrega 2 mentiras ridículas."
-  },
-  {
-    "id": 14,
-    "text": "Baila como si el piso estuviera hirviendo durante 20 segundos."
-  },
-  {
-    "id": 15,
-    "text": "Envía un audio diciendo: 'No debimos tocar eso…' sin contexto."
-  },
-  {
-    "id": 16,
-    "text": "Convéncenos de que serías líder perfecto en un apocalipsis zombie."
-  },
-  { "id": 17, "text": "Actúa como superhéroe cuyo poder sea tu peor defecto." },
-  {
-    "id": 18,
-    "text": "Inventa un gadget con 3 objetos cercanos y ponle nombre absurdo."
-  },
-  {
-    "id": 19,
-    "text": "Dos personas controlan tu voz y tus movimientos por 30 segundos."
-  },
-  {
-    "id": 20,
-    "text": "Envía el mensaje: 'El plan B está en marcha 🦆' a un contacto aleatorio."
-  },
-
-  {
-    "id": 21,
-    "text": "Explica una teoría loca con una cuchara en la boca (máx. 20 segundos)."
-  },
-  {
-    "id": 22,
-    "text": "Inventa un baile inspirado en un animal elegido por el grupo."
-  },
-  {
-    "id": 23,
-    "text": "Con los ojos cerrados, prueba algo y adivina qué es (2 intentos)."
-  },
-  { "id": 24, "text": "Declara tu amor eterno a un objeto de la habitación." },
-  {
-    "id": 25,
-    "text": "Narra un videojuego imaginario como streamer exagerado."
-  },
-  {
-    "id": 26,
-    "text": "Imita a un político anunciando algo completamente absurdo."
-  },
-  {
-    "id": 27,
-    "text": "Construye algo inútil pero explícalo como si fuera revolucionario."
-  },
-  {
-    "id": 28,
-    "text": "Envía: '¿Seguimos con lo que prometimos?' y no expliques nada."
-  },
-  {
-    "id": 29,
-    "text": "Imita a un famoso mientras comes una galleta sin reírte."
-  },
-  { "id": 30, "text": "Dibuja a alguien del grupo con los ojos cerrados." },
-
-  { "id": 31, "text": "Inventa un idioma y pide comida rápida en él." },
-  {
-    "id": 32,
-    "text": "Gira 5 veces y camina en línea recta con total seguridad falsa."
-  },
-  { "id": 33, "text": "Resuelve un crimen imaginario ultra ridículo." },
-  {
-    "id": 34,
-    "text": "Deslízate por el piso como si fuera una pista de hielo."
-  },
-  { "id": 35, "text": "Escribe tu nombre en el aire usando solo el codo." },
-  {
-    "id": 36,
-    "text": "Envía: 'Funcionó mejor de lo esperado…' a tu último chat."
-  },
-  { "id": 37, "text": "Vende algo inútil como si fuera una necesidad básica." },
-  {
-    "id": 38,
-    "text": "Defiende al grupo de una invasión imaginaria durante 30 segundos."
-  },
-  {
-    "id": 39,
-    "text": "Camina como pingüino elegante rumbo a una alfombra roja."
-  },
-  { "id": 40, "text": "Rap improvisado sobre una tarea que odias hacer." },
-
-  { "id": 41, "text": "Entrevista a un objeto como si fuera famoso." },
-  { "id": 42, "text": "Cuenta una historia de terror… caminando hacia atrás." },
-  {
-    "id": 43,
-    "text": "Sube una foto con filtro exagerado y déjala 5 minutos."
-  },
-  { "id": 44, "text": "Predice el futuro absurdo del grupo como adivino." },
-  { "id": 45, "text": "Envía un audio cantando cumpleaños sin razón." },
-  {
-    "id": 46,
-    "text": "Salva al grupo de un ataque imaginario con una toalla-capa."
-  },
-  { "id": 47, "text": "Reacciona a ganar la lotería usando solo sonidos." },
-  { "id": 48, "text": "Reconoce manos del grupo con los ojos cerrados." },
-  { "id": 49, "text": "Crea un comercial exprés con objetos de la mesa." },
-  { "id": 50, "text": "Podcast improvisado sobre un tema absurdo del grupo." },
-
-  { "id": 51, "text": "Aplaude con objetos frágiles sin romperlos." },
-  { "id": 52, "text": "Inventa un saludo secreto grupal." },
-  { "id": 53, "text": "Presenta una receta terrible como chef famoso." },
-  { "id": 54, "text": "Crea un invento para un problema ridículo del grupo." },
-  {
-    "id": 55,
-    "text": "Graba un 'life hack' completamente inútil con mucha seguridad."
-  },
-  { "id": 56, "text": "Desfila con un objeto en la cabeza sin que caiga." },
-  { "id": 57, "text": "Canción improvisada usando solo una letra." },
-  {
-    "id": 58,
-    "text": "Da una clase exprés sobre cómo sobrevivir al aburrimiento."
-  },
-  {
-    "id": 59,
-    "text": "Despídete dramáticamente como si te fueras del planeta."
-  },
-  {
-    "id": 60,
-    "text": "Inventa un baile que represente esperar el baño en una fiesta."
-  }
+  "Imita al amigo del grupo que más exagera al contar historias.",
+  "Deja que el grupo elija una foto de tu galería para verla durante 8 segundos.",
+  "Envía un audio cantando como ópera a un contacto aleatorio.",
+  "Haz 15 sentadillas narrando lo que haces como si fuera un documental épico.",
+  "Publica en tu estado: 'Acepto teorías conspirativas, inbox abierto'.",
+  "Baila 30 segundos como si la música fuera increíble… aunque no haya música.",
+  "Habla 1 minuto sin usar las palabras: yo, sí, no.",
+  "Canta el coro de una canción famosa usando solo tarareos dramáticos.",
+  "Graba un TikTok actuando como si fueras famoso y nadie te reconociera.",
+  "Desfila como modelo, pero cada 5 segundos cambia de emoción exageradamente.",
+  "Envía un mensaje: 'Tenemos que hablar… luego te explico' y no respondas por 10 minutos.",
+  "Vende un objeto común como si costara millones (el grupo decide si lo compra).",
+  "Cuenta una historia real… pero agrega 2 mentiras ridículas.",
+  "Baila como si el piso estuviera hirviendo durante 20 segundos.",
+  "Envía un audio diciendo: 'No debimos tocar eso…' sin contexto.",
+  "Convéncenos de que serías líder perfecto en un apocalipsis zombie.",
+  "Actúa como superhéroe cuyo poder sea tu peor defecto.",
+  "Inventa un gadget con 3 objetos cercanos y ponle nombre absurdo.",
+  "Dos personas controlan tu voz y tus movimientos por 30 segundos.",
+  "Envía el mensaje: 'El plan B está en marcha 🦆' a un contacto aleatorio.",
+  "Explica una teoría loca con una cuchara en la boca (máx. 20 segundos).",
+  "Inventa un baile inspirado en un animal elegido por el grupo.",
+  "Con los ojos cerrados, prueba algo y adivina qué es (2 intentos).",
+  "Declara tu amor eterno a un objeto de la habitación.",
+  "Narra un videojuego imaginario como streamer exagerado.",
+  "Imita a un político anunciando algo completamente absurdo.",
+  "Construye algo inútil pero explícalo como si fuera revolucionario.",
+  "Envía: '¿Seguimos con lo que prometimos?' y no expliques nada.",
+  "Imita a un famoso mientras comes una galleta sin reírte.",
+  "Dibuja a alguien del grupo con los ojos cerrados.",
+  "Inventa un idioma y pide comida rápida en él.",
+  "Gira 5 veces y camina en línea recta con total seguridad falsa.",
+  "Resuelve un crimen imaginario ultra ridículo.",
+  "Deslízate por el piso como si fuera una pista de hielo.",
+  "Escribe tu nombre en el aire usando solo el codo.",
+  "Envía: 'Funcionó mejor de lo esperado…' a tu último chat.",
+  "Vende algo inútil como si fuera una necesidad básica.",
+  "Defiende al grupo de una invasión imaginaria durante 30 segundos.",
+  "Camina como pingüino elegante rumbo a una alfombra roja.",
+  "Rap improvisado sobre una tarea que odias hacer.",
+  "Entrevista a un objeto como si fuera famoso.",
+  "Cuenta una historia de terror… caminando hacia atrás.",
+  "Sube una foto con filtro exagerado y déjala 5 minutos.",
+  "Predice el futuro absurdo del grupo como adivino.",
+  "Envía un audio cantando cumpleaños sin razón.",
+  "Salva al grupo de un ataque imaginario con una toalla-capa.",
+  "Reacciona a ganar la lotería usando solo sonidos.",
+  "Reconoce manos del grupo con los ojos cerrados.",
+  "Crea un comercial exprés con objetos de la mesa.",
+  "Podcast improvisado sobre un tema absurdo del grupo.",
+  "Aplaude con objetos frágiles sin romperlos.",
+  "Inventa un saludo secreto grupal.",
+  "Presenta una receta terrible como chef famoso.",
+  "Crea un invento para un problema ridículo del grupo.",
+  "Graba un 'life hack' completamente inútil con mucha seguridad.",
+  "Desfila con un objeto en la cabeza sin que caiga.",
+  "Canción improvisada usando solo una letra.",
+  "Da una clase exprés sobre cómo sobrevivir al aburrimiento.",
+  "Despídete dramáticamente como si te fueras del planeta.",
+  "Inventa un baile que represente esperar el baño en una fiesta."
 ]

--- a/src/data/retos/amigos-verdad.json
+++ b/src/data/retos/amigos-verdad.json
@@ -1,184 +1,67 @@
 [
-  {
-    "id": 1,
-    "text": "¿Qué hábito tuyo sabes que desespera al grupo aunque nadie lo diga?"
-  },
-  { "id": 2, "text": "¿Alguna vez revelaste un secreto sin darte cuenta?" },
-  {
-    "id": 3,
-    "text": "¿Qué cosa hiciste solo para encajar y hoy te da vergüenza?"
-  },
-  {
-    "id": 4,
-    "text": "¿Con quién del grupo chocarías más si vivieran juntos y por qué?"
-  },
-  {
-    "id": 5,
-    "text": "¿Qué mentira pequeña le has dicho al grupo que todos creen?"
-  },
-  {
-    "id": 6,
-    "text": "¿Alguna vez te gustaron dos personas al mismo tiempo del mismo círculo?"
-  },
-  { "id": 7, "text": "¿Qué crees que el grupo critica de ti cuando no estás?" },
-  { "id": 8, "text": "¿Qué elogio te marcó más de alguien que está aquí?" },
-  {
-    "id": 9,
-    "text": "Si solo pudieras llevar a un amigo a una isla desierta, ¿a quién eliges y por qué?"
-  },
-  {
-    "id": 10,
-    "text": "¿Qué excusa falsa usaste para cancelar un plan grupal?"
-  },
-
-  {
-    "id": 11,
-    "text": "¿Qué situación inocente podría verse muy rara fuera de contexto?"
-  },
-  {
-    "id": 12,
-    "text": "Si tuvieras que vender a un amigo como producto, ¿a quién y con qué slogan?"
-  },
-  {
-    "id": 13,
-    "text": "¿Cuál es el rumor más ridículo que escuchaste sobre ti?"
-  },
-  { "id": 14, "text": "¿Qué moda seguiste y hoy no entiendes por qué?" },
-  {
-    "id": 15,
-    "text": "Si el grupo fuera una mafia, ¿qué rol tendrías tú realmente?"
-  },
-  { "id": 16, "text": "¿Quién sería el peor roommate del grupo y por qué?" },
-  { "id": 17, "text": "Si fueran una banda, ¿qué rol tendría cada uno?" },
-  { "id": 18, "text": "¿Qué chiste interno del grupo jamás debería morir?" },
-  { "id": 19, "text": "¿Qué apodo vergonzoso de tu infancia nunca cuentas?" },
-  {
-    "id": 20,
-    "text": "¿Qué palabra o frase de un amigo eliminarías para siempre?"
-  },
-
-  {
-    "id": 21,
-    "text": "¿A quién mandarías a un reality show solo para ver el caos?"
-  },
-  { "id": 22, "text": "¿Qué mentira complicada has sostenido más tiempo?" },
-  {
-    "id": 23,
-    "text": "¿Qué haces cuando estás solo que jamás admitirías frente a extraños?"
-  },
-  {
-    "id": 24,
-    "text": "Si el grupo recreara una película famosa, ¿quién arruinaría la escena?"
-  },
-  {
-    "id": 25,
-    "text": "¿Quién sería el peor líder del mundo y qué ley absurda crearía?"
-  },
-  {
-    "id": 26,
-    "text": "¿Qué hábito de un amigo te cuesta tolerar pero nunca dices?"
-  },
-  {
-    "id": 27,
-    "text": "¿Qué defecto tuyo heredaría el grupo si fueran tus hijos?"
-  },
-  { "id": 28, "text": "¿Qué objeto inútil guardas 'por si acaso'?" },
-  {
-    "id": 29,
-    "text": "¿Quién da los peores consejos sentimentales del grupo?"
-  },
-  {
-    "id": 30,
-    "text": "Si intercambiaras cuerpo con alguien del grupo, ¿con quién y por qué?"
-  },
-
-  {
-    "id": 31,
-    "text": "¿Qué comentario tuyo en un chat grupal te arrepentiste de enviar?"
-  },
-  {
-    "id": 32,
-    "text": "¿Qué foto o video del grupo nunca debería salir a la luz?"
-  },
-  {
-    "id": 33,
-    "text": "Si el grupo fuera arrestado, ¿por qué crees que sería?"
-  },
-  { "id": 34, "text": "¿Qué mentira todos creen sobre ti y nunca corregiste?" },
-  {
-    "id": 35,
-    "text": "¿Quién sería más difícil de convivir en un viaje largo?"
-  },
-  {
-    "id": 36,
-    "text": "¿Cuál fue la excusa más mala que usaste para zafar de un plan?"
-  },
-  {
-    "id": 37,
-    "text": "¿Qué momento vergonzoso borrarías de la memoria del grupo?"
-  },
-  {
-    "id": 38,
-    "text": "¿Qué costumbre del grupo sería rarísima vista desde afuera?"
-  },
-  {
-    "id": 39,
-    "text": "¿Quién sería el primero en fallar en un apocalipsis zombie?"
-  },
-  {
-    "id": 40,
-    "text": "¿A quién llevarías como cita a un evento familiar sin miedo al escándalo?"
-  },
-
-  {
-    "id": 41,
-    "text": "¿Qué pensamiento random tienes sobre cada persona aquí?"
-  },
-  { "id": 42, "text": "¿Quién sería incapaz de cuidar incluso una planta?" },
-  {
-    "id": 43,
-    "text": "¿Qué mentira tonta dijiste para impresionar a alguien?"
-  },
-  {
-    "id": 44,
-    "text": "Si fueran superhéroes, ¿qué poder inútil tendría cada uno?"
-  },
-  { "id": 45, "text": "¿Quién arruinaría una boda sin querer?" },
-  { "id": 46, "text": "¿Qué talento inútil solo sacas en fiestas?" },
-  { "id": 47, "text": "Si fueran desastres naturales, ¿qué sería cada uno?" },
-  { "id": 48, "text": "¿Qué momento grupal te hizo reír hasta doler?" },
-  { "id": 49, "text": "¿Con qué 3 emojis crees que el grupo te describiría?" },
-  {
-    "id": 50,
-    "text": "Si este grupo fuera un reality, ¿cuál sería el drama principal?"
-  },
-
-  { "id": 51, "text": "¿Qué detalle cotidiano del grupo extrañarías más?" },
-  {
-    "id": 52,
-    "text": "¿Qué apodo le pondrías a cada uno según su peor hábito?"
-  },
-  { "id": 53, "text": "¿Qué cualidad robarías de cada amigo?" },
-  {
-    "id": 54,
-    "text": "¿Qué recuerdo del grupo sería peligroso si se hiciera viral?"
-  },
-  {
-    "id": 55,
-    "text": "¿Con quiénes sobrevivirías mejor una semana y por qué?"
-  },
-  { "id": 56, "text": "¿Qué secreto tuyo cambiaría la forma en que te ven?" },
-  { "id": 57, "text": "Si fueran sabores de helado, ¿cuál sería cada uno?" },
-  {
-    "id": 58,
-    "text": "¿Qué situación incómoda presenciaste y fingiste no ver?"
-  },
-  {
-    "id": 59,
-    "text": "¿Qué rasgo de personalidad cambiarías de alguien del grupo?"
-  },
-  {
-    "id": 60,
-    "text": "¿Qué historia del grupo siempre exageras cuando la cuentas?"
-  }
+  "¿Qué hábito tuyo sabes que desespera al grupo aunque nadie lo diga?",
+  "¿Alguna vez revelaste un secreto sin darte cuenta?",
+  "¿Qué cosa hiciste solo para encajar y hoy te da vergüenza?",
+  "¿Con quién del grupo chocarías más si vivieran juntos y por qué?",
+  "¿Qué mentira pequeña le has dicho al grupo que todos creen?",
+  "¿Alguna vez te gustaron dos personas al mismo tiempo del mismo círculo?",
+  "¿Qué crees que el grupo critica de ti cuando no estás?",
+  "¿Qué elogio te marcó más de alguien que está aquí?",
+  "Si solo pudieras llevar a un amigo a una isla desierta, ¿a quién eliges y por qué?",
+  "¿Qué excusa falsa usaste para cancelar un plan grupal?",
+  "¿Qué situación inocente podría verse muy rara fuera de contexto?",
+  "Si tuvieras que vender a un amigo como producto, ¿a quién y con qué slogan?",
+  "¿Cuál es el rumor más ridículo que escuchaste sobre ti?",
+  "¿Qué moda seguiste y hoy no entiendes por qué?",
+  "Si el grupo fuera una mafia, ¿qué rol tendrías tú realmente?",
+  "¿Quién sería el peor roommate del grupo y por qué?",
+  "Si fueran una banda, ¿qué rol tendría cada uno?",
+  "¿Qué chiste interno del grupo jamás debería morir?",
+  "¿Qué apodo vergonzoso de tu infancia nunca cuentas?",
+  "¿Qué palabra o frase de un amigo eliminarías para siempre?",
+  "¿A quién mandarías a un reality show solo para ver el caos?",
+  "¿Qué mentira complicada has sostenido más tiempo?",
+  "¿Qué haces cuando estás solo que jamás admitirías frente a extraños?",
+  "Si el grupo recreara una película famosa, ¿quién arruinaría la escena?",
+  "¿Quién sería el peor líder del mundo y qué ley absurda crearía?",
+  "¿Qué hábito de un amigo te cuesta tolerar pero nunca dices?",
+  "¿Qué defecto tuyo heredaría el grupo si fueran tus hijos?",
+  "¿Qué objeto inútil guardas 'por si acaso'?",
+  "¿Quién da los peores consejos sentimentales del grupo?",
+  "Si intercambiaras cuerpo con alguien del grupo, ¿con quién y por qué?",
+  "¿Qué comentario tuyo en un chat grupal te arrepentiste de enviar?",
+  "¿Qué foto o video del grupo nunca debería salir a la luz?",
+  "Si el grupo fuera arrestado, ¿por qué crees que sería?",
+  "¿Qué mentira todos creen sobre ti y nunca corregiste?",
+  "¿Quién sería más difícil de convivir en un viaje largo?",
+  "¿Cuál fue la excusa más mala que usaste para zafar de un plan?",
+  "¿Qué momento vergonzoso borrarías de la memoria del grupo?",
+  "¿Qué costumbre del grupo sería rarísima vista desde afuera?",
+  "¿Quién sería el primero en fallar en un apocalipsis zombie?",
+  "¿A quién llevarías como cita a un evento familiar sin miedo al escándalo?",
+  "¿Qué pensamiento random tienes sobre cada persona aquí?",
+  "¿Quién sería incapaz de cuidar incluso una planta?",
+  "¿Qué mentira tonta dijiste para impresionar a alguien?",
+  "Si fueran superhéroes, ¿qué poder inútil tendría cada uno?",
+  "¿Quién arruinaría una boda sin querer?",
+  "¿Qué talento inútil solo sacas en fiestas?",
+  "Si fueran desastres naturales, ¿qué sería cada uno?",
+  "¿Qué momento grupal te hizo reír hasta doler?",
+  "¿Con qué 3 emojis crees que el grupo te describiría?",
+  "Si este grupo fuera un reality, ¿cuál sería el drama principal?",
+  "¿Qué detalle cotidiano del grupo extrañarías más?",
+  "¿Qué apodo le pondrías a cada uno según su peor hábito?",
+  "¿Qué cualidad robarías de cada amigo?",
+  "¿Qué recuerdo del grupo sería peligroso si se hiciera viral?",
+  "¿Con quiénes sobrevivirías mejor una semana y por qué?",
+  "¿Qué secreto tuyo cambiaría la forma en que te ven?",
+  "Si fueran sabores de helado, ¿cuál sería cada uno?",
+  "¿Qué situación incómoda presenciaste y fingiste no ver?",
+  "¿Qué rasgo de personalidad cambiarías de alguien del grupo?",
+  "¿Qué historia del grupo siempre exageras cuando la cuentas?",
+  "¿A quién del grupo le costaría más sobrevivir sin internet por una semana entera?",
+  "¿Cuál es la cosa más ridícula que hiciste para impresionar a alguien del grupo cuando recién los conociste?",
+  "¿Qué consejo que te dio alguien del grupo seguiste y resultó ser el peor de tu vida?",
+  "¿Cuál es el tema que nunca falla para que el grupo tenga una discusión interminable?",
+  "¿Qué cosa de alguien del grupo nunca te ha gustado pero jamás le has dicho directamente?"
 ]

--- a/src/data/retos/chicas-reto.json
+++ b/src/data/retos/chicas-reto.json
@@ -1,211 +1,62 @@
 [
-  {
-    "id": 1,
-    "text": "Haz un tutorial exagerado de 'Cómo caminar con dignidad después de una noche larga'."
-  },
-  {
-    "id": 2,
-    "text": "Dibuja tu versión del crush ideal usando solo tu mano no dominante."
-  },
-  {
-    "id": 3,
-    "text": "Explica con dramatismo extremo cómo sobrevivirías a un cierre de brasier roto (sin demostrarlo)."
-  },
-  {
-    "id": 4,
-    "text": "Haz una parodia de desfile quitándote capas imaginarias de ropa como si fuera alta costura."
-  },
-  {
-    "id": 5,
-    "text": "Inventa un eslogan para un producto femenino inventado (ej: 'pañuelos para lágrimas de ex')."
-  },
-  {
-    "id": 6,
-    "text": "Actúa cómo sería tu versión de la 'chica villana' en una película escolar."
-  },
-  {
-    "id": 7,
-    "text": "Con un objeto en la cabeza, camina como modelo en una pasarela imaginaria."
-  },
-  {
-    "id": 8,
-    "text": "Graba un audio imitando a una influencer dando el peor consejo posible."
-  },
-  {
-    "id": 9,
-    "text": "Diseña un tatuaje simbólico (falso) con lápiz labial que represente a otra del grupo."
-  },
-  {
-    "id": 10,
-    "text": "Con los ojos cerrados, identifica cosméticos solo por el olor."
-  },
-
-  {
-    "id": 11,
-    "text": "Haz una sesión de fotos 'para Instagram' con los objetos más absurdos de la habitación."
-  },
-  {
-    "id": 12,
-    "text": "Con una toalla como vestido, recrea una escena dramática de telenovela."
-  },
-  {
-    "id": 13,
-    "text": "Haz un tutorial de 'Cómo fingir que sabes de vinos' usando agua."
-  },
-  {
-    "id": 14,
-    "text": "Diseña un vestido de novia extravagante usando solo papel higiénico."
-  },
-  {
-    "id": 15,
-    "text": "Exige hablar con el gerente… por algo completamente absurdo."
-  },
-  { "id": 16, "text": "Con los ojos cerrados, dibuja a una chica del grupo." },
-  {
-    "id": 17,
-    "text": "Finge ser una psíquica y predice el futuro amoroso de otra amiga."
-  },
-  {
-    "id": 18,
-    "text": "Demuestra cómo caminarías con seguridad absoluta aunque estés muy nerviosa."
-  },
-  { "id": 19, "text": "Tómate una selfie con tu peor ángulo a propósito." },
-  {
-    "id": 20,
-    "text": "Actúa como influencer fitness promoviendo ejercicios para superar una ruptura."
-  },
-
-  {
-    "id": 21,
-    "text": "Imita a cada chica del grupo en 5 segundos — ellas deben adivinar a quién estás imitando."
-  },
-  {
-    "id": 22,
-    "text": "Crea un look de fiesta con lo que tengas a mano y desfilalo."
-  },
-  {
-    "id": 23,
-    "text": "Inventa un baile de TikTok que represente 'amigas antes que todo'."
-  },
-  {
-    "id": 24,
-    "text": "Escribe un mensaje de voz de 15 segundos al primer contacto hombre de tu WhatsApp diciendo que lo extrañas, sin explicación."
-  },
-  { "id": 25, "text": "Haz tu mejor drama de telenovela: llora y confiesa algo completamente inventado durante 30 segundos sin reírte." },
-  {
-    "id": 26,
-    "text": "Crea una coreografía de 3 movimientos que represente la amistad femenina."
-  },
-  {
-    "id": 27,
-    "text": "Con una sábana, diseña un vestido de alfombra roja y desfila."
-  },
-  {
-    "id": 28,
-    "text": "Imita a una celebridad haciendo su rutina exagerada de autocuidado."
-  },
-  {
-    "id": 29,
-    "text": "Haz un mini podcast sobre los peores consejos amorosos que existen."
-  },
-  { "id": 30, "text": "Confiesa en voz alta tu crush más vergonzoso del colegio o universidad. Con nombre y todo." },
-
-  {
-    "id": 31,
-    "text": "Actúa como chef presentando el 'postre que cura corazones rotos'."
-  },
-  {
-    "id": 32,
-    "text": "Inventa un lenguaje secreto para comunicarte con amigas en fiestas aburridas."
-  },
-  {
-    "id": 33,
-    "text": "Deja que el grupo elija tu foto de perfil de WhatsApp y la cambies en ese momento durante 10 minutos."
-  },
-  {
-    "id": 34,
-    "text": "Crea una rutina ridícula para recuperar el ego después de un ghosteo."
-  },
-  { "id": 35, "text": "Haz un comercial para 'gafas que detectan red flags'." },
-  {
-    "id": 36,
-    "text": "Peina a otra chica con los ojos cerrados (sin usar calor)."
-  },
-  {
-    "id": 37,
-    "text": "Inventa un himno de amigas usando una melodía infantil."
-  },
-  { "id": 38, "text": "Haz un desfile de modas con ropa puesta al revés." },
-  { "id": 39, "text": "Crea un kit de supervivencia para citas desastrosas." },
-  {
-    "id": 40,
-    "text": "Actúa como terapeuta dando consejos absurdamente honestos."
-  },
-
-  {
-    "id": 41,
-    "text": "Haz un tutorial de cómo responder con clase a comentarios incómodos."
-  },
-  {
-    "id": 42,
-    "text": "Crea un baile que represente cuando tu amiga menciona a su ex otra vez."
-  },
-  {
-    "id": 43,
-    "text": "Baila 30 segundos sin música mientras el grupo inventa el nombre ridículo del baile que estás haciendo."
-  },
-  {
-    "id": 44,
-    "text": "Di un piropo exagerado y teatral a cada chica del grupo, una por una, sin repetir ninguno."
-  },
-  {
-    "id": 45,
-    "text": "Haz un anuncio de radio para dejar de stalkear en redes."
-  },
-  {
-    "id": 46,
-    "text": "Demuestra poses de selfie para fingir que todo está bien."
-  },
-  {
-    "id": 47,
-    "text": "Crea una coreografía para una noche de chicas perfecta."
-  },
-  {
-    "id": 48,
-    "text": "Haz un tutorial de cómo caminar segura aunque algo salga mal."
-  },
-  {
-    "id": 49,
-    "text": "Actúa sin palabras cómo recibirías la peor noticia de tu vida y luego la mejor — el grupo adivina qué fue cada una."
-  },
-  { "id": 50, "text": "Convence al grupo en 60 segundos de que eres la mejor candidata para un reality de chicas. Improvisa el discurso." },
-
-  {
-    "id": 51,
-    "text": "Actúa como influencer enseñando cómo parecer ocupada y exitosa."
-  },
-  {
-    "id": 52,
-    "text": "Haz un comercial para una crema anti-estrés emocional."
-  },
-  {
-    "id": 53,
-    "text": "Haz un peinado creativo a otra chica con los ojos cerrados."
-  },
-  { "id": 54, "text": "Mantén la cara completamente seria durante 60 segundos mientras el grupo hace todo lo posible por hacerte reír." },
-  {
-    "id": 55,
-    "text": "Crea un baile para rescatar a una amiga de una cita aburrida."
-  },
-  {
-    "id": 56,
-    "text": "Haz un tutorial para sonreír cuando hacen preguntas incómodas."
-  },
-  { "id": 57, "text": "Diseña un traje de poder con periódico." },
-  { "id": 58, "text": "Inventa un himno para noches de chicas sin drama." },
-  { "id": 59, "text": "Haz un comercial para una alarma anti-frases tóxicas." },
-  {
-    "id": 60,
-    "text": "Crea un altar simbólico a la amistad y haz una mini ceremonia."
-  }
+  "Haz un tutorial exagerado de 'Cómo caminar con dignidad después de una noche larga'.",
+  "Dibuja tu versión del crush ideal usando solo tu mano no dominante.",
+  "Explica con dramatismo extremo cómo sobrevivirías a un cierre de brasier roto (sin demostrarlo).",
+  "Haz una parodia de desfile quitándote capas imaginarias de ropa como si fuera alta costura.",
+  "Inventa un eslogan para un producto femenino inventado (ej: 'pañuelos para lágrimas de ex').",
+  "Actúa cómo sería tu versión de la 'chica villana' en una película escolar.",
+  "Con un objeto en la cabeza, camina como modelo en una pasarela imaginaria.",
+  "Graba un audio imitando a una influencer dando el peor consejo posible.",
+  "Diseña un tatuaje simbólico (falso) con lápiz labial que represente a otra del grupo.",
+  "Con los ojos cerrados, identifica cosméticos solo por el olor.",
+  "Haz una sesión de fotos 'para Instagram' con los objetos más absurdos de la habitación.",
+  "Con una toalla como vestido, recrea una escena dramática de telenovela.",
+  "Haz un tutorial de 'Cómo fingir que sabes de vinos' usando agua.",
+  "Diseña un vestido de novia extravagante usando solo papel higiénico.",
+  "Exige hablar con el gerente… por algo completamente absurdo.",
+  "Con los ojos cerrados, dibuja a una chica del grupo.",
+  "Finge ser una psíquica y predice el futuro amoroso de otra amiga.",
+  "Demuestra cómo caminarías con seguridad absoluta aunque estés muy nerviosa.",
+  "Tómate una selfie con tu peor ángulo a propósito.",
+  "Actúa como influencer fitness promoviendo ejercicios para superar una ruptura.",
+  "Imita a cada chica del grupo en 5 segundos — ellas deben adivinar a quién estás imitando.",
+  "Crea un look de fiesta con lo que tengas a mano y desfilalo.",
+  "Inventa un baile de TikTok que represente 'amigas antes que todo'.",
+  "Escribe un mensaje de voz de 15 segundos al primer contacto hombre de tu WhatsApp diciendo que lo extrañas, sin explicación.",
+  "Haz tu mejor drama de telenovela: llora y confiesa algo completamente inventado durante 30 segundos sin reírte.",
+  "Crea una coreografía de 3 movimientos que represente la amistad femenina.",
+  "Con una sábana, diseña un vestido de alfombra roja y desfila.",
+  "Imita a una celebridad haciendo su rutina exagerada de autocuidado.",
+  "Haz un mini podcast sobre los peores consejos amorosos que existen.",
+  "Confiesa en voz alta tu crush más vergonzoso del colegio o universidad. Con nombre y todo.",
+  "Actúa como chef presentando el 'postre que cura corazones rotos'.",
+  "Inventa un lenguaje secreto para comunicarte con amigas en fiestas aburridas.",
+  "Deja que el grupo elija tu foto de perfil de WhatsApp y la cambies en ese momento durante 10 minutos.",
+  "Crea una rutina ridícula para recuperar el ego después de un ghosteo.",
+  "Haz un comercial para 'gafas que detectan red flags'.",
+  "Peina a otra chica con los ojos cerrados (sin usar calor).",
+  "Inventa un himno de amigas usando una melodía infantil.",
+  "Haz un desfile de modas con ropa puesta al revés.",
+  "Crea un kit de supervivencia para citas desastrosas.",
+  "Actúa como terapeuta dando consejos absurdamente honestos.",
+  "Haz un tutorial de cómo responder con clase a comentarios incómodos.",
+  "Crea un baile que represente cuando tu amiga menciona a su ex otra vez.",
+  "Baila 30 segundos sin música mientras el grupo inventa el nombre ridículo del baile que estás haciendo.",
+  "Di un piropo exagerado y teatral a cada chica del grupo, una por una, sin repetir ninguno.",
+  "Haz un anuncio de radio para dejar de stalkear en redes.",
+  "Demuestra poses de selfie para fingir que todo está bien.",
+  "Crea una coreografía para una noche de chicas perfecta.",
+  "Haz un tutorial de cómo caminar segura aunque algo salga mal.",
+  "Actúa sin palabras cómo recibirías la peor noticia de tu vida y luego la mejor — el grupo adivina qué fue cada una.",
+  "Convence al grupo en 60 segundos de que eres la mejor candidata para un reality de chicas. Improvisa el discurso.",
+  "Actúa como influencer enseñando cómo parecer ocupada y exitosa.",
+  "Haz un comercial para una crema anti-estrés emocional.",
+  "Haz un peinado creativo a otra chica con los ojos cerrados.",
+  "Mantén la cara completamente seria durante 60 segundos mientras el grupo hace todo lo posible por hacerte reír.",
+  "Crea un baile para rescatar a una amiga de una cita aburrida.",
+  "Haz un tutorial para sonreír cuando hacen preguntas incómodas.",
+  "Diseña un traje de poder con periódico.",
+  "Inventa un himno para noches de chicas sin drama.",
+  "Haz un comercial para una alarma anti-frases tóxicas.",
+  "Crea un altar simbólico a la amistad y haz una mini ceremonia."
 ]

--- a/src/data/retos/chicas-verdad.json
+++ b/src/data/retos/chicas-verdad.json
@@ -1,242 +1,67 @@
 [
-  {
-    "id": 1,
-    "text": "¿Cuál es el peor consejo que te dio una amiga?"
-  },
-  {
-    "id": 2,
-    "text": "¿Qué outfit tuyo causó más miradas de otras mujeres (de admiración o envidia)?"
-  },
-  {
-    "id": 3,
-    "text": "¿Qué cosa 'inocente' has hecho que otras podrían considerar una jugada calculada?"
-  },
-  {
-    "id": 4,
-    "text": "¿Alguna vez enviaste un mensaje al contacto equivocado? ¿Qué decía y cómo reaccionaste?"
-  },
-  {
-    "id": 5,
-    "text": "Si tuvieras que vender a tu mejor amiga en una cita, ¿qué destacarías de ella?"
-  },
-  {
-    "id": 6,
-    "text": "¿Qué hábito masculino detestas pero finges tolerar?"
-  },
-  {
-    "id": 7,
-    "text": "¿Cuál ha sido tu mayor desastre en una cita?"
-  },
-  {
-    "id": 8,
-    "text": "Si tu vida amorosa fuera un meme, ¿cuál sería?"
-  },
-  {
-    "id": 9,
-    "text": "¿Cuál es la red flag más grande que ignoraste completamente porque la persona te gustaba demasiado?"
-  },
-  {
-    "id": 10,
-    "text": "¿Cuál es el peor pecado de belleza que has cometido por pereza?"
-  },
-  {
-    "id": 11,
-    "text": "¿Qué app de citas has usado en secreto y nunca lo admitirías en público?"
-  },
-  {
-    "id": 12,
-    "text": "¿Qué canción pop vergonzosa te gusta para sentirte poderosa?"
-  },
-  {
-    "id": 13,
-    "text": "¿Cuál es tu mayor talento femenino que nadie aprecia?"
-  },
-  {
-    "id": 14,
-    "text": "¿Qué mentira has dicho sobre tu periodo para salir de una situación?"
-  },
-  {
-    "id": 15,
-    "text": "¿Qué cosa 'de chicas' odias pero participas para no ser la rara del grupo?"
-  },
-  {
-    "id": 16,
-    "text": "¿Cuál ha sido el momento en que más celos sentiste de otra mujer? ¿Lo admitiste o lo ocultaste?"
-  },
-  {
-    "id": 17,
-    "text": "¿Qué haces en secreto cuando estás completamente sola que nunca harías si alguien te viera?"
-  },
-  {
-    "id": 18,
-    "text": "¿Cual es la excusa mas ridícula que has usado para salir de una cita?"
-  },
-  {
-    "id": 19,
-    "text": "¿Cuál es la cosa más patética que has hecho por un chico que te gustaba?"
-  },
-  {
-    "id": 20,
-    "text": "¿Qué amiga del grupo sería la peor para elegir como dama de honor y por qué?"
-  },
-  {
-    "id": 21,
-    "text": "¿Cuál es el peor regalo que te ha dado un ex y fingiste que te gustó?"
-  },
-  {
-    "id": 22,
-    "text": "¿Qué amiga del grupo tiene el peor gusto para los hombres y por qué?"
-  },
-  {
-    "id": 23,
-    "text": "¿Cuál es la mentira más grande que has dicho sobre tu número de parejas sexuales?"
-  },
-  {
-    "id": 24,
-    "text": "¿Qué producto de belleza compras en secreto que te da vergüenza admitir?"
-  },
-  {
-    "id": 25,
-    "text": "¿Cuál es tu mayor drama familiar que nunca le has contado a tus amigas?"
-  },
-  {
-    "id": 26,
-    "text": "¿Qué talento oculto tienes que solo muestras cuando estás con tus amigas más cercanas?"
-  },
-  {
-    "id": 27,
-    "text": "Si tuvieras que describir a cada amiga aquí con un tipo de café, ¿cuál sería cada una?"
-  },
-  {
-    "id": 28,
-    "text": "¿Alguna vez has buscado a tu ex en redes sociales después de una ruptura? ¿Cuántas veces y hasta cuándo?"
-  },
-  {
-    "id": 29,
-    "text": "¿Qué ritual de belleza extraño o poco convencional haces que funcionaría para todas?"
-  },
-  {
-    "id": 30,
-    "text": "Si fueran un grupo de superhéroes, ¿cuál sería el superpoder de cada una y qué nombre tendrían?"
-  },
-  {
-    "id": 31,
-    "text": "¿Qué canción femenina empoderadora te hace sentir invencible cuando la escuchas?"
-  },
-  {
-    "id": 32,
-    "text": "¿Cuál es el mejor consejo que una amiga te ha dado que cambió tu perspectiva?"
-  },
-  {
-    "id": 33,
-    "text": "¿Has fingido alguna vez que te gustaba alguien solo por no herir sus sentimientos? ¿Cuánto duró?"
-  },
-  {
-    "id": 34,
-    "text": "Si tuvieran que abrir un negocio juntas, ¿qué sería y por qué tendría éxito?"
-  },
-  {
-    "id": 35,
-    "text": "¿Qué outfit te hace sentir más poderosa y por qué?"
-  },
-  {
-    "id": 36,
-    "text": "¿Cuál es la cosa más divertida que han hecho juntas que nunca contarían en una entrevista de trabajo?"
-  },
-  {
-    "id": 37,
-    "text": "¿Cuál es lo más 'stalker' que has hecho por alguien que te gustaba y nunca le has contado a nadie?"
-  },
-  {
-    "id": 38,
-    "text": "¿Qué habilidad de otra chica del grupo te gustaría tener y por qué?"
-  },
-  {
-    "id": 39,
-    "text": "¿Cuál es la historia más vergonzosa de tu adolescencia que ahora puedes reírte con tus amigas?"
-  },
-  {
-    "id": 40,
-    "text": "¿Qué cosa 'de chicas' te daba vergüenza antes pero ahora celebras?"
-  },
-  {
-    "id": 41,
-    "text": "Si tuvieran que hacer un viaje de chicas, ¿a dónde irían y qué harían el primer día?"
-  },
-  {
-    "id": 42,
-    "text": "¿Cuál es el cumplido más bonito que te ha dado otra mujer?"
-  },
-  {
-    "id": 43,
-    "text": "¿Qué serie o película de amigas se parece más a su grupo y por qué?"
-  },
-  {
-    "id": 44,
-    "text": "¿Qué lección importante aprendiste de una amiga que tu familia nunca te enseñó?"
-  },
-  {
-    "id": 45,
-    "text": "¿Cuál es su canción grupal no oficial y qué memoria especial tienen con ella?"
-  },
-  {
-    "id": 46,
-    "text": "Si tuvieran que escribir un libro sobre su amistad, ¿qué título tendría y de qué trataría?"
-  },
-  {
-    "id": 47,
-    "text": "¿Qué cosa ridícula han hecho juntas cuando estaban aburridas?"
-  },
-  {
-    "id": 48,
-    "text": "¿Cuál es la mejor cualidad de cada amiga aquí presente que admiras secretamente?"
-  },
-  {
-    "id": 49,
-    "text": "¿Alguna vez le has contado a una amiga algo íntimo de otra del grupo? ¿Cuándo y por qué?"
-  },
-  {
-    "id": 50,
-    "text": "¿Cuál es la comida o bebida que siempre piden cuando están teniendo una noche de chicas?"
-  },
-  {
-    "id": 51,
-    "text": "¿Qué memes o videos internos del grupo todavía los hacen reír cada vez que los ven?"
-  },
-  {
-    "id": 52,
-    "text": "Si pudieras planear el día perfecto con tus amigas sin límite de presupuesto, ¿qué incluiría?"
-  },
-  {
-    "id": 53,
-    "text": "¿Qué momento juntas los hizo sentir más unidas como grupo de amigas?"
-  },
-  {
-    "id": 54,
-    "text": "¿Cuál es el peor error de moda o belleza que cometiste y tus amigas te salvaron de él?"
-  },
-  {
-    "id": 55,
-    "text": "¿Tienes un crush actual que nadie del grupo sabe? Da 3 pistas sin decir el nombre."
-  },
-  {
-    "id": 56,
-    "text": "¿Qué película romántica o de comedia siempre ven juntas y conocen todos los diálogos?"
-  },
-  {
-    "id": 57,
-    "text": "¿Cuál es la cosa más dulce que una amiga ha hecho por ti sin que se lo pidieras?"
-  },
-  {
-    "id": 58,
-    "text": "¿Cuál es el momento más vergonzoso que has vivido frente a alguien que te gustaba? Cuéntalo con todos los detalles."
-  },
-  {
-    "id": 59,
-    "text": "¿Qué momento incómodo compartieron que ahora es una anécdota graciosa?"
-  },
-  {
-    "id": 60,
-    "text": "¿Cuál es la frase o dicho que siempre repiten cuando están juntas?"
-  }
+  "¿Cuál es el peor consejo que te dio una amiga?",
+  "¿Qué outfit tuyo causó más miradas de otras mujeres (de admiración o envidia)?",
+  "¿Qué cosa 'inocente' has hecho que otras podrían considerar una jugada calculada?",
+  "¿Alguna vez enviaste un mensaje al contacto equivocado? ¿Qué decía y cómo reaccionaste?",
+  "Si tuvieras que vender a tu mejor amiga en una cita, ¿qué destacarías de ella?",
+  "¿Qué hábito masculino detestas pero finges tolerar?",
+  "¿Cuál ha sido tu mayor desastre en una cita?",
+  "Si tu vida amorosa fuera un meme, ¿cuál sería?",
+  "¿Cuál es la red flag más grande que ignoraste completamente porque la persona te gustaba demasiado?",
+  "¿Cuál es el peor pecado de belleza que has cometido por pereza?",
+  "¿Qué app de citas has usado en secreto y nunca lo admitirías en público?",
+  "¿Qué canción pop vergonzosa te gusta para sentirte poderosa?",
+  "¿Cuál es tu mayor talento femenino que nadie aprecia?",
+  "¿Qué mentira has dicho sobre tu periodo para salir de una situación?",
+  "¿Qué cosa 'de chicas' odias pero participas para no ser la rara del grupo?",
+  "¿Cuál ha sido el momento en que más celos sentiste de otra mujer? ¿Lo admitiste o lo ocultaste?",
+  "¿Qué haces en secreto cuando estás completamente sola que nunca harías si alguien te viera?",
+  "¿Cual es la excusa mas ridícula que has usado para salir de una cita?",
+  "¿Cuál es la cosa más patética que has hecho por un chico que te gustaba?",
+  "¿Qué amiga del grupo sería la peor para elegir como dama de honor y por qué?",
+  "¿Cuál es el peor regalo que te ha dado un ex y fingiste que te gustó?",
+  "¿Qué amiga del grupo tiene el peor gusto para los hombres y por qué?",
+  "¿Cuál es la mentira más grande que has dicho sobre tu número de parejas sexuales?",
+  "¿Qué producto de belleza compras en secreto que te da vergüenza admitir?",
+  "¿Cuál es tu mayor drama familiar que nunca le has contado a tus amigas?",
+  "¿Qué talento oculto tienes que solo muestras cuando estás con tus amigas más cercanas?",
+  "Si tuvieras que describir a cada amiga aquí con un tipo de café, ¿cuál sería cada una?",
+  "¿Alguna vez has buscado a tu ex en redes sociales después de una ruptura? ¿Cuántas veces y hasta cuándo?",
+  "¿Qué ritual de belleza extraño o poco convencional haces que funcionaría para todas?",
+  "Si fueran un grupo de superhéroes, ¿cuál sería el superpoder de cada una y qué nombre tendrían?",
+  "¿Qué canción femenina empoderadora te hace sentir invencible cuando la escuchas?",
+  "¿Cuál es el mejor consejo que una amiga te ha dado que cambió tu perspectiva?",
+  "¿Has fingido alguna vez que te gustaba alguien solo por no herir sus sentimientos? ¿Cuánto duró?",
+  "Si tuvieran que abrir un negocio juntas, ¿qué sería y por qué tendría éxito?",
+  "¿Qué outfit te hace sentir más poderosa y por qué?",
+  "¿Cuál es la cosa más divertida que han hecho juntas que nunca contarían en una entrevista de trabajo?",
+  "¿Cuál es lo más 'stalker' que has hecho por alguien que te gustaba y nunca le has contado a nadie?",
+  "¿Qué habilidad de otra chica del grupo te gustaría tener y por qué?",
+  "¿Cuál es la historia más vergonzosa de tu adolescencia que ahora puedes reírte con tus amigas?",
+  "¿Qué cosa 'de chicas' te daba vergüenza antes pero ahora celebras?",
+  "Si tuvieran que hacer un viaje de chicas, ¿a dónde irían y qué harían el primer día?",
+  "¿Cuál es el cumplido más bonito que te ha dado otra mujer?",
+  "¿Qué serie o película de amigas se parece más a su grupo y por qué?",
+  "¿Qué lección importante aprendiste de una amiga que tu familia nunca te enseñó?",
+  "¿Cuál es su canción grupal no oficial y qué memoria especial tienen con ella?",
+  "Si tuvieran que escribir un libro sobre su amistad, ¿qué título tendría y de qué trataría?",
+  "¿Qué cosa ridícula han hecho juntas cuando estaban aburridas?",
+  "¿Cuál es la mejor cualidad de cada amiga aquí presente que admiras secretamente?",
+  "¿Alguna vez le has contado a una amiga algo íntimo de otra del grupo? ¿Cuándo y por qué?",
+  "¿Cuál es la comida o bebida que siempre piden cuando están teniendo una noche de chicas?",
+  "¿Qué memes o videos internos del grupo todavía los hacen reír cada vez que los ven?",
+  "Si pudieras planear el día perfecto con tus amigas sin límite de presupuesto, ¿qué incluiría?",
+  "¿Qué momento juntas los hizo sentir más unidas como grupo de amigas?",
+  "¿Cuál es el peor error de moda o belleza que cometiste y tus amigas te salvaron de él?",
+  "¿Tienes un crush actual que nadie del grupo sabe? Da 3 pistas sin decir el nombre.",
+  "¿Qué película romántica o de comedia siempre ven juntas y conocen todos los diálogos?",
+  "¿Cuál es la cosa más dulce que una amiga ha hecho por ti sin que se lo pidieras?",
+  "¿Cuál es el momento más vergonzoso que has vivido frente a alguien que te gustaba? Cuéntalo con todos los detalles.",
+  "¿Qué momento incómodo compartieron que ahora es una anécdota graciosa?",
+  "¿Cuál es la frase o dicho que siempre repiten cuando están juntas?",
+  "¿Cuál es la compra de ropa o moda de la que más te has arrepentido y que todavía tienes en el armario?",
+  "¿Qué momento de tu vida te gustaría revivir exactamente como fue, sin cambiar absolutamente nada?",
+  "¿Qué cosa te dices a ti misma por las mañanas que ninguna otra persona sabe?",
+  "Si pudieras dar un solo consejo a tu yo de hace cinco años, ¿qué le dirías?",
+  "¿Cuál es la cualidad que más admiras de ti misma pero que rara vez te permites reconocer en voz alta?"
 ]

--- a/src/data/retos/clasico-reto.json
+++ b/src/data/retos/clasico-reto.json
@@ -1,242 +1,62 @@
 [
-  {
-    "id": 1,
-    "text": "Bebe un vaso de agua sin usar las manos."
-  },
-  {
-    "id": 2,
-    "text": "Camina como modelo por la habitación."
-  },
-  {
-    "id": 3,
-    "text": "Haz 10 flexiones seguidas."
-  },
-  {
-    "id": 4,
-    "text": "Dibuja algo con los ojos cerrados y que el grupo adivine."
-  },
-  {
-    "id": 5,
-    "text": "Imita a un famoso hasta que alguien adivine."
-  },
-  {
-    "id": 6,
-    "text": "Come algo sin usar las manos."
-  },
-  {
-    "id": 7,
-    "text": "Habla con acento extranjero por 3 turnos."
-  },
-  {
-    "id": 8,
-    "text": "Haz un baile ridículo por 20 segundos."
-  },
-  {
-    "id": 9,
-    "text": "Dile a alguien por mensaje: 'Sé tu secreto'."
-  },
-  {
-    "id": 10,
-    "text": "Equilibra una cuchara en tu nariz durante 15 segundos."
-  },
-  {
-    "id": 11,
-    "text": "Escribe una palabra en el aire con el codo (¡el grupo debe adivinar qué escribiste!)."
-  },
-  {
-    "id": 12,
-    "text": "Canta el abecedario en reversa lo más rápido que puedas."
-  },
-  {
-    "id": 13,
-    "text": "Deja que alguien del grupo te haga un peinado extravagante y exhibelo por 5 minutos."
-  },
-  {
-    "id": 14,
-    "text": "Con una cuchara en la boca, di 'Cuchara de palo' 5 veces rápido."
-  },
-  {
-    "id": 15,
-    "text": "Usa calcetines en las manos y intenta abrir una botella o paquete de galletas."
-  },
-  {
-    "id": 16,
-    "text": "Con los ojos cerrados, adivina qué objeto del grupo te están poniendo en las manos (tienes 3 intentos)."
-  },
-  {
-    "id": 17,
-    "text": "Inventa un eslogan publicitario ridículo para el último miembro del grupo que habló."
-  },
-  {
-    "id": 18,
-    "text": "Con una moneda en la frente, intenta que caiga dentro de un vaso sin usar las manos."
-  },
-  {
-    "id": 19,
-    "text": "Con una mano en la cabeza y otra en el estómago, frota círculos en ambas mientras cantas 'Cumpleaños feliz'."
-  },
-  {
-    "id": 20,
-    "text": "Con una cuchara sostenida con los dientes, intenta recoger un objeto pequeño (ej: un garbanzo)."
-  },
-  {
-    "id": 21,
-    "text": "Con los ojos vendados, identifica a un miembro del grupo solo tocando su cabello (tienes 2 intentos)."
-  },
-  {
-    "id": 22,
-    "text": "Inventa un lenguaje alienígena y explica cómo pedirías pizza en él (el grupo debe adivinar)."
-  },
-  {
-    "id": 23,
-    "text": "Con una galleta en la frente, intenta que caiga en tu boca solo moviendo las cejas."
-  },
-  {
-    "id": 24,
-    "text": "Usa una escoba como guitarra y canta el coro de una canción inventada sobre 'la pésima suerte'."
-  },
-  {
-    "id": 25,
-    "text": "Con los ojos cerrados, dibuja un perro en una hoja mientras el grupo te da instrucciones absurdas."
-  },
-  {
-    "id": 26,
-    "text": "Con un calcetín en cada mano, intenta desdoblar un pañuelo facial."
-  },
-  {
-    "id": 27,
-    "text": "Actúa como si fueras un/a presentador/a de televentas vendiendo el objeto más aburrido de la habitación."
-  },
-  {
-    "id": 28,
-    "text": "Haz una 'escultura' con 3 objetos cercanos que represente tu personalidad y explícala."
-  },
-  {
-    "id": 29,
-    "text": "Envía un mensaje de voz a un contacto aleatorio diciendo: 'Confirmado: el dragón llegó al castillo'."
-  },
-  {
-    "id": 30,
-    "text": "Con una cuchara en cada mano, intenta aplaudir sin soltarlas (¡el sonido más ridículo gana!)."
-  },
-  {
-    "id": 31,
-    "text": "Imita a un animal mientras comes un snack sin reírte (el grupo adivina qué animal eres)."
-  },
-  {
-    "id": 32,
-    "text": "Con los ojos vendados, identifica 3 objetos comunes solo por el olfato (¡nada de zapatos sucios!)."
-  },
-  {
-    "id": 33,
-    "text": "Inventa un baile inspirado en un electrodoméstico (ej: la licuadora) y enséñaselo al grupo."
-  },
-  {
-    "id": 34,
-    "text": "Con un libro en la cabeza, camina en línea recta mientras recitas un trabalenguas."
-  },
-  {
-    "id": 35,
-    "text": "Usa una fruta como micrófono y canta una canción de amor... como si fueras un gallo."
-  },
-  {
-    "id": 36,
-    "text": "Escribe tu nombre en el suelo con el pie dominante, mientras mantienes equilibrio en un pie."
-  },
-  {
-    "id": 37,
-    "text": "Envía un audio a un contacto aleatorio diciendo: 'El experimento salió mal... repito, SALIÓ MAL'."
-  },
-  {
-    "id": 38,
-    "text": "Equilibra tres objetos diferentes en tu cabeza mientras caminas por la habitación."
-  },
-  {
-    "id": 39,
-    "text": "Imita a tres animales diferentes y que el grupo adivine cuáles son."
-  },
-  {
-    "id": 40,
-    "text": "Con los ojos cerrados, dibuja la cara de alguien del grupo y que adivinen de quién es."
-  },
-  {
-    "id": 41,
-    "text": "Haz una torre con 10 objetos diferentes y mantenla en pie por 20 segundos."
-  },
-  {
-    "id": 42,
-    "text": "Inventa una historia de 1 minuto usando solo palabras que empiecen con la letra 'P'."
-  },
-  {
-    "id": 43,
-    "text": "Haz una competencia de miradas con alguien del grupo por 2 minutos sin reír."
-  },
-  {
-    "id": 44,
-    "text": "Con una cuchara en la nariz, intenta comer un snack de un plato"
-  },
-  {
-    "id": 45,
-    "text": "Haz un baile que imite a un robot con fallas técnicas"
-  },
-  {
-    "id": 46,
-    "text": "Con los ojos vendados, arma un rompecabezas de 4 piezas (que el grupo prepare)"
-  },
-  {
-    "id": 47,
-    "text": "Imita a un mime atrapado en una caja invisible por 30 segundos"
-  },
-  {
-    "id": 48,
-    "text": "Con una servilleta en cada pie, intenta escribir tu inicial en el suelo"
-  },
-  {
-    "id": 49,
-    "text": "Haz como si fueras un conductor de autobús anunciando paradas absurdas"
-  },
-  {
-    "id": 50,
-    "text": "Con una galleta salada en cada rodilla, camina sin que se caigan"
-  },
-  {
-    "id": 51,
-    "text": "Inventa un deporte nuevo usando solo un cojín y una botella vacía"
-  },
-  {
-    "id": 52,
-    "text": "Con los ojos cerrados, identifica a 3 personas del grupo solo por su voz"
-  },
-  {
-    "id": 53,
-    "text": "Haz un comercial de televisión para un producto que no existe"
-  },
-  {
-    "id": 54,
-    "text": "Con una pelota pequeña, haz malabares por 15 segundos (¡puedes usar cualquier parte del cuerpo!)"
-  },
-  {
-    "id": 55,
-    "text": "Imita a un personaje de dibujos animados hablando sobre el clima"
-  },
-  {
-    "id": 56,
-    "text": "Con un rollo de papel, crea un sombrero extravagante y preséntalo como diseñador/a"
-  },
-  {
-    "id": 57,
-    "text": "Haz una rutina de ejercicios imaginarios para 'fortalecer el sentido del humor'"
-  },
-  {
-    "id": 58,
-    "text": "Con una cuchara y un tenedor como baquetas, toca una batería imaginaria"
-  },
-  {
-    "id": 59,
-    "text": "Imita a un turista perdido pidiendo direcciones en un idioma inventado"
-  },
-  {
-    "id": 60,
-    "text": "Con tres vasos de agua, crea una 'melodía' tocándolos con diferentes objetos"
-  }
+  "Bebe un vaso de agua sin usar las manos.",
+  "Camina como modelo por la habitación.",
+  "Haz 10 flexiones seguidas.",
+  "Dibuja algo con los ojos cerrados y que el grupo adivine.",
+  "Imita a un famoso hasta que alguien adivine.",
+  "Come algo sin usar las manos.",
+  "Habla con acento extranjero por 3 turnos.",
+  "Haz un baile ridículo por 20 segundos.",
+  "Dile a alguien por mensaje: 'Sé tu secreto'.",
+  "Equilibra una cuchara en tu nariz durante 15 segundos.",
+  "Escribe una palabra en el aire con el codo (¡el grupo debe adivinar qué escribiste!).",
+  "Canta el abecedario en reversa lo más rápido que puedas.",
+  "Deja que alguien del grupo te haga un peinado extravagante y exhibelo por 5 minutos.",
+  "Con una cuchara en la boca, di 'Cuchara de palo' 5 veces rápido.",
+  "Usa calcetines en las manos y intenta abrir una botella o paquete de galletas.",
+  "Con los ojos cerrados, adivina qué objeto del grupo te están poniendo en las manos (tienes 3 intentos).",
+  "Inventa un eslogan publicitario ridículo para el último miembro del grupo que habló.",
+  "Con una moneda en la frente, intenta que caiga dentro de un vaso sin usar las manos.",
+  "Con una mano en la cabeza y otra en el estómago, frota círculos en ambas mientras cantas 'Cumpleaños feliz'.",
+  "Con una cuchara sostenida con los dientes, intenta recoger un objeto pequeño (ej: un garbanzo).",
+  "Con los ojos vendados, identifica a un miembro del grupo solo tocando su cabello (tienes 2 intentos).",
+  "Inventa un lenguaje alienígena y explica cómo pedirías pizza en él (el grupo debe adivinar).",
+  "Con una galleta en la frente, intenta que caiga en tu boca solo moviendo las cejas.",
+  "Usa una escoba como guitarra y canta el coro de una canción inventada sobre 'la pésima suerte'.",
+  "Con los ojos cerrados, dibuja un perro en una hoja mientras el grupo te da instrucciones absurdas.",
+  "Con un calcetín en cada mano, intenta desdoblar un pañuelo facial.",
+  "Actúa como si fueras un/a presentador/a de televentas vendiendo el objeto más aburrido de la habitación.",
+  "Haz una 'escultura' con 3 objetos cercanos que represente tu personalidad y explícala.",
+  "Envía un mensaje de voz a un contacto aleatorio diciendo: 'Confirmado: el dragón llegó al castillo'.",
+  "Con una cuchara en cada mano, intenta aplaudir sin soltarlas (¡el sonido más ridículo gana!).",
+  "Imita a un animal mientras comes un snack sin reírte (el grupo adivina qué animal eres).",
+  "Con los ojos vendados, identifica 3 objetos comunes solo por el olfato (¡nada de zapatos sucios!).",
+  "Inventa un baile inspirado en un electrodoméstico (ej: la licuadora) y enséñaselo al grupo.",
+  "Con un libro en la cabeza, camina en línea recta mientras recitas un trabalenguas.",
+  "Usa una fruta como micrófono y canta una canción de amor... como si fueras un gallo.",
+  "Escribe tu nombre en el suelo con el pie dominante, mientras mantienes equilibrio en un pie.",
+  "Envía un audio a un contacto aleatorio diciendo: 'El experimento salió mal... repito, SALIÓ MAL'.",
+  "Equilibra tres objetos diferentes en tu cabeza mientras caminas por la habitación.",
+  "Imita a tres animales diferentes y que el grupo adivine cuáles son.",
+  "Con los ojos cerrados, dibuja la cara de alguien del grupo y que adivinen de quién es.",
+  "Haz una torre con 10 objetos diferentes y mantenla en pie por 20 segundos.",
+  "Inventa una historia de 1 minuto usando solo palabras que empiecen con la letra 'P'.",
+  "Haz una competencia de miradas con alguien del grupo por 2 minutos sin reír.",
+  "Con una cuchara en la nariz, intenta comer un snack de un plato",
+  "Haz un baile que imite a un robot con fallas técnicas",
+  "Con los ojos vendados, arma un rompecabezas de 4 piezas (que el grupo prepare)",
+  "Imita a un mime atrapado en una caja invisible por 30 segundos",
+  "Con una servilleta en cada pie, intenta escribir tu inicial en el suelo",
+  "Haz como si fueras un conductor de autobús anunciando paradas absurdas",
+  "Con una galleta salada en cada rodilla, camina sin que se caigan",
+  "Inventa un deporte nuevo usando solo un cojín y una botella vacía",
+  "Con los ojos cerrados, identifica a 3 personas del grupo solo por su voz",
+  "Haz un comercial de televisión para un producto que no existe",
+  "Con una pelota pequeña, haz malabares por 15 segundos (¡puedes usar cualquier parte del cuerpo!)",
+  "Imita a un personaje de dibujos animados hablando sobre el clima",
+  "Con un rollo de papel, crea un sombrero extravagante y preséntalo como diseñador/a",
+  "Haz una rutina de ejercicios imaginarios para 'fortalecer el sentido del humor'",
+  "Con una cuchara y un tenedor como baquetas, toca una batería imaginaria",
+  "Imita a un turista perdido pidiendo direcciones en un idioma inventado",
+  "Con tres vasos de agua, crea una 'melodía' tocándolos con diferentes objetos"
 ]

--- a/src/data/retos/clasico-verdad.json
+++ b/src/data/retos/clasico-verdad.json
@@ -1,242 +1,67 @@
 [
-  {
-    "id": 1,
-    "text": "¿Cuál es tu mayor miedo?"
-  },
-  {
-    "id": 2,
-    "text": "¿Qué es lo más extraño que has comido?"
-  },
-  {
-    "id": 3,
-    "text": "¿Alguna vez has llorado por un examen o trabajo?"
-  },
-  {
-    "id": 4,
-    "text": "¿Qué canción te da vergüenza que te guste?"
-  },
-  {
-    "id": 5,
-    "text": "¿Qué cosa infantil aún disfrutas?"
-  },
-  {
-    "id": 6,
-    "text": "¿Qué app usas más y por qué?"
-  },
-  {
-    "id": 7,
-    "text": "¿Qué habilidad te gustaría tener y por qué nunca la aprendiste?"
-  },
-  {
-    "id": 8,
-    "text": "Si solo pudieras comer un alimento por el resto de tu vida, ¿cuál sería?"
-  },
-  {
-    "id": 9,
-    "text": "¿Qué personaje de ficción odias con toda tu alma?"
-  },
-  {
-    "id": 10,
-    "text": "¿Cuál es el peor regalo que has recibido y fingiste que te gustó?"
-  },
-  {
-    "id": 11,
-    "text": "¿Qué cosa 'normal' te parece extrañamente aterradora?"
-  },
-  {
-    "id": 12,
-    "text": "¿Qué cosa común haces de manera completamente incorrecta y nunca te diste cuenta hasta que alguien te lo señaló?"
-  },
-  {
-    "id": 13,
-    "text": "Si fueras un villano, ¿cuál sería tu origen trágico y tu plan malvado?"
-  },
-  {
-    "id": 14,
-    "text": "¿Cuál es la mentira más inútil que has mantenido por años?"
-  },
-  {
-    "id": 15,
-    "text": "¿Qué habilidad inútil dominaste durante la cuarentena?"
-  },
-  {
-    "id": 16,
-    "text": "¿Qué objeto en tu casa parece normal pero tiene una historia ridícula detrás?"
-  },
-  {
-    "id": 17,
-    "text": "¿Qué cosa 'de adulto' te emociona tanto que te sientes ridícul@?"
-  },
-  {
-    "id": 18,
-    "text": "Si tu vida fuera un reality show, ¿cuál sería el título y por qué?"
-  },
-  {
-    "id": 19,
-    "text": "¿Qué regla familiar de tu infancia te parecía normal hasta que creciste?"
-  },
-  {
-    "id": 20,
-    "text": "¿Qué trabajo harías aunque te pagaran el mínimo salario, solo por diversión?"
-  },
-  {
-    "id": 21,
-    "text": "¿Qué película o serie te da vergüenza admitir que nunca has visto?"
-  },
-  {
-    "id": 22,
-    "text": "¿Qué canción infantil te avergüenza conocer completa (letra y movimientos)?"
-  },
-  {
-    "id": 23,
-    "text": "Si tuvieras que vivir en una década pasada, ¿cuál sería y qué extrañarías más del presente?"
-  },
-  {
-    "id": 24,
-    "text": "¿Qué mentira inocente le dijiste a tus padres que aún creen?"
-  },
-  {
-    "id": 25,
-    "text": "¿Qué objeto de tu infancia guardas 'por nostalgia' aunque sea completamente inútil?"
-  },
-  {
-    "id": 26,
-    "text": "Si pudieras borrar un programa de TV o película de la existencia, ¿cuál sería y por qué?"
-  },
-  {
-    "id": 27,
-    "text": "¿Qué habilidad básica de adulto aún no dominas (ej: cambiar llanta, cocinar huevo)?"
-  },
-  {
-    "id": 28,
-    "text": "¿Qué chiste malo siempre te hace reír aunque no debería?"
-  },
-  {
-    "id": 29,
-    "text": "¿Qué moda pasada (ej: pantalones ultra bajos) extrañas secretamente?"
-  },
-  {
-    "id": 30,
-    "text": "¿Qué frase de tu abuela/madre repites sin darte cuenta?"
-  },
-  {
-    "id": 31,
-    "text": "Si tu vida tuviera un narrador como en los documentales, ¿qué diría ahora mismo sobre ti?"
-  },
-  {
-    "id": 32,
-    "text": "¿Qué hábito de tu infancia te daría vergüenza que tus amigos descubrieran que aún conservas?"
-  },
-  {
-    "id": 33,
-    "text": "Si tuvieras que convertirte en un personaje de dibujos animados por una semana, ¿cuál serías y por qué?"
-  },
-  {
-    "id": 34,
-    "text": "¿Qué mentira dijiste de niño que tus padres aún creen y te recuerdan periódicamente?"
-  },
-  {
-    "id": 35,
-    "text": "¿Qué objeto común usaste de manera completamente incorrecta hasta que alguien te corrigió?"
-  },
-  {
-    "id": 36,
-    "text": "Si tu vida tuviera una banda sonora de errores, ¿qué canción sonaría cada vez que metes la pata?"
-  },
-  {
-    "id": 37,
-    "text": "¿Qué superpoder infantil imaginabas tener que ahora te parece completamente ridículo?"
-  },
-  {
-    "id": 38,
-    "text": "¿Qué promesa te hiciste de niño ('nunca haré X cuando sea grande') que terminaste rompiendo espectacularmente?"
-  },
-  {
-    "id": 39,
-    "text": "¿Qué trabajo soñabas tener de pequeño que ahora te parece el peor empleo posible?"
-  },
-  {
-    "id": 40,
-    "text": "¿Qué moda escolar seguiste que hoy hace que quieras borrar esas fotos de la existencia?"
-  },
-  {
-    "id": 41,
-    "text": "Si tuvieras que explicar tu peor corte de cabello con un título de película, ¿cuál sería?"
-  },
-  {
-    "id": 42,
-    "text": "¿Cuál es la cosa más extraña que has hecho cuando estabas solo en casa?"
-  },
-  {
-    "id": 43,
-    "text": "¿Qué comida te da asco pero finges que te gusta para no ser descortés?"
-  },
-  {
-    "id": 44,
-    "text": "¿Qué celebridad famosa crees que serías si fueras del sexo opuesto?"
-  },
-  {
-    "id": 45,
-    "text": "¿Qué habilidad inútil tienes que nadie más sabe?"
-  },
-  {
-    "id": 46,
-    "text": "¿Qué plato sabes cocinar tan mal que ni tú mismo te lo comerías?"
-  },
-  {
-    "id": 47,
-    "text": "Si tuvieras que describir tu personalidad con un tipo de clima, ¿cuál serías y por qué?"
-  },
-  {
-    "id": 48,
-    "text": "¿Qué programa de TV ves en secreto que nadie sospecharía que te gusta?"
-  },
-  {
-    "id": 49,
-    "text": "¿Cuál es la cosa más 'boomer' que haces regularmente?"
-  },
-  {
-    "id": 50,
-    "text": "Si tu mente fuera una casa, ¿qué habitación estaría siempre desordenada?"
-  },
-  {
-    "id": 51,
-    "text": "¿Qué canción conoces completa aunque jurarías que no la has escuchado en años?"
-  },
-  {
-    "id": 52,
-    "text": "¿Qué superstición ridícula sigues aunque sabes que no tiene sentido?"
-  },
-  {
-    "id": 53,
-    "text": "Si fueras un animal doméstico, ¿qué dueño ideal serías y por qué?"
-  },
-  {
-    "id": 54,
-    "text": "¿Qué cosa de la tecnología moderna todavía no entiendes completamente?"
-  },
-  {
-    "id": 55,
-    "text": "¿Cuál es el sonido más irritante para ti y por qué lo detestas tanto?"
-  },
-  {
-    "id": 56,
-    "text": "Si tuvieras que comer solo un color de comida por el resto de tu vida, ¿cuál elegirías?"
-  },
-  {
-    "id": 57,
-    "text": "¿Qué trabajo temporal tuviste que fue tan malo que te prometiste nunca volver?"
-  },
-  {
-    "id": 58,
-    "text": "¿Cuál es la cosa más 'de viejo' que haces antes de las 9 PM?"
-  },
-  {
-    "id": 59,
-    "text": "Si tu vida fuera un videojuego, ¿qué logro sería el más difícil de desbloquear?"
-  },
-  {
-    "id": 60,
-    "text": "¿Qué cosa común te emociona tanto que te sientes un poco ridículo?"
-  }
+  "¿Cuál es tu mayor miedo?",
+  "¿Qué es lo más extraño que has comido?",
+  "¿Alguna vez has llorado por un examen o trabajo?",
+  "¿Qué canción te da vergüenza que te guste?",
+  "¿Qué cosa infantil aún disfrutas?",
+  "¿Qué app usas más y por qué?",
+  "¿Qué habilidad te gustaría tener y por qué nunca la aprendiste?",
+  "Si solo pudieras comer un alimento por el resto de tu vida, ¿cuál sería?",
+  "¿Qué personaje de ficción odias con toda tu alma?",
+  "¿Cuál es el peor regalo que has recibido y fingiste que te gustó?",
+  "¿Qué cosa 'normal' te parece extrañamente aterradora?",
+  "¿Qué cosa común haces de manera completamente incorrecta y nunca te diste cuenta hasta que alguien te lo señaló?",
+  "Si fueras un villano, ¿cuál sería tu origen trágico y tu plan malvado?",
+  "¿Cuál es la mentira más inútil que has mantenido por años?",
+  "¿Qué habilidad inútil dominaste durante la cuarentena?",
+  "¿Qué objeto en tu casa parece normal pero tiene una historia ridícula detrás?",
+  "¿Qué cosa 'de adulto' te emociona tanto que te sientes ridícul@?",
+  "Si tu vida fuera un reality show, ¿cuál sería el título y por qué?",
+  "¿Qué regla familiar de tu infancia te parecía normal hasta que creciste?",
+  "¿Qué trabajo harías aunque te pagaran el mínimo salario, solo por diversión?",
+  "¿Qué película o serie te da vergüenza admitir que nunca has visto?",
+  "¿Qué canción infantil te avergüenza conocer completa (letra y movimientos)?",
+  "Si tuvieras que vivir en una década pasada, ¿cuál sería y qué extrañarías más del presente?",
+  "¿Qué mentira inocente le dijiste a tus padres que aún creen?",
+  "¿Qué objeto de tu infancia guardas 'por nostalgia' aunque sea completamente inútil?",
+  "Si pudieras borrar un programa de TV o película de la existencia, ¿cuál sería y por qué?",
+  "¿Qué habilidad básica de adulto aún no dominas (ej: cambiar llanta, cocinar huevo)?",
+  "¿Qué chiste malo siempre te hace reír aunque no debería?",
+  "¿Qué moda pasada (ej: pantalones ultra bajos) extrañas secretamente?",
+  "¿Qué frase de tu abuela/madre repites sin darte cuenta?",
+  "Si tu vida tuviera un narrador como en los documentales, ¿qué diría ahora mismo sobre ti?",
+  "¿Qué hábito de tu infancia te daría vergüenza que tus amigos descubrieran que aún conservas?",
+  "Si tuvieras que convertirte en un personaje de dibujos animados por una semana, ¿cuál serías y por qué?",
+  "¿Qué mentira dijiste de niño que tus padres aún creen y te recuerdan periódicamente?",
+  "¿Qué objeto común usaste de manera completamente incorrecta hasta que alguien te corrigió?",
+  "Si tu vida tuviera una banda sonora de errores, ¿qué canción sonaría cada vez que metes la pata?",
+  "¿Qué superpoder infantil imaginabas tener que ahora te parece completamente ridículo?",
+  "¿Qué promesa te hiciste de niño ('nunca haré X cuando sea grande') que terminaste rompiendo espectacularmente?",
+  "¿Qué trabajo soñabas tener de pequeño que ahora te parece el peor empleo posible?",
+  "¿Qué moda escolar seguiste que hoy hace que quieras borrar esas fotos de la existencia?",
+  "Si tuvieras que explicar tu peor corte de cabello con un título de película, ¿cuál sería?",
+  "¿Cuál es la cosa más extraña que has hecho cuando estabas solo en casa?",
+  "¿Qué comida te da asco pero finges que te gusta para no ser descortés?",
+  "¿Qué celebridad famosa crees que serías si fueras del sexo opuesto?",
+  "¿Qué habilidad inútil tienes que nadie más sabe?",
+  "¿Qué plato sabes cocinar tan mal que ni tú mismo te lo comerías?",
+  "Si tuvieras que describir tu personalidad con un tipo de clima, ¿cuál serías y por qué?",
+  "¿Qué programa de TV ves en secreto que nadie sospecharía que te gusta?",
+  "¿Cuál es la cosa más 'boomer' que haces regularmente?",
+  "Si tu mente fuera una casa, ¿qué habitación estaría siempre desordenada?",
+  "¿Qué canción conoces completa aunque jurarías que no la has escuchado en años?",
+  "¿Qué superstición ridícula sigues aunque sabes que no tiene sentido?",
+  "Si fueras un animal doméstico, ¿qué dueño ideal serías y por qué?",
+  "¿Qué cosa de la tecnología moderna todavía no entiendes completamente?",
+  "¿Cuál es el sonido más irritante para ti y por qué lo detestas tanto?",
+  "Si tuvieras que comer solo un color de comida por el resto de tu vida, ¿cuál elegirías?",
+  "¿Qué trabajo temporal tuviste que fue tan malo que te prometiste nunca volver?",
+  "¿Cuál es la cosa más 'de viejo' que haces antes de las 9 PM?",
+  "Si tu vida fuera un videojuego, ¿qué logro sería el más difícil de desbloquear?",
+  "¿Qué cosa común te emociona tanto que te sientes un poco ridículo?",
+  "¿Qué libro has fingido haber leído para parecer más culto?",
+  "Si pudieras cenar con cualquier persona de la historia, ¿quién sería y qué le preguntarías primero?",
+  "¿Cuál es la cosa más cara que compraste impulsivamente y de la que más te arrepentiste?",
+  "¿Qué habilidad crees que dominas pero en realidad haces bastante mal?",
+  "Si tuvieras que vivir en otro país por un año sin poder elegir, ¿cuál sería el peor que te podría tocar y por qué?"
 ]

--- a/src/data/retos/extremo-reto.json
+++ b/src/data/retos/extremo-reto.json
@@ -1,242 +1,62 @@
 [
-  {
-    "id": 1,
-    "text": "Elige a alguien y enséñale exactamente cómo te gusta que te toquen, guiando su mano con instrucciones específicas"
-  },
-  {
-    "id": 2,
-    "text": "Intercambien una prenda íntima y úsenla como requisito para el siguiente nivel de intimidad"
-  },
-  {
-    "id": 3,
-    "text": "Crea un 'ritual de 3 pasos' para pasar del juego al sexo, y demuestra el primer paso ahora"
-  },
-  {
-    "id": 4,
-    "text": "Elige un objeto común de la habitación y conviértelo en juguete sexual con tu imaginación"
-  },
-  {
-    "id": 5,
-    "text": "Susurra al oído de tu pareja exactamente qué harás con su cuerpo cuando terminen de jugar"
-  },
-  {
-    "id": 6,
-    "text": "Demuestra con movimientos pélvicos el ritmo que quieres para la penetración o fricción"
-  },
-  {
-    "id": 7,
-    "text": "Quítate una prenda de ropa usando solo una mano, mostrando cómo lo harías como preludio sexual"
-  },
-  {
-    "id": 8,
-    "text": "Inventa un código de 3 gestos con las manos para usar durante el sexo (más rápido, más lento, cambiar posición)"
-  },
-  {
-    "id": 9,
-    "text": "Con una fruta, demuestra cómo te gusta que te den sexo oral"
-  },
-  {
-    "id": 10,
-    "text": "Elige una superficie en esta habitación y muestra cómo la usarías para tener relaciones"
-  },
-  {
-    "id": 11,
-    "text": "Crea una 'lista de deseos íntimos' de 3 cosas que quieres hacer antes de que amanezca"
-  },
-  {
-    "id": 12,
-    "text": "Con un cubo de hielo, demuestra en tu propio cuerpo dónde te gusta que te lo usen durante el sexo"
-  },
-  {
-    "id": 13,
-    "text": "Simula un orgasmo realista que dure exactamente 20 segundos, incluyendo respiración y movimientos"
-  },
-  {
-    "id": 14,
-    "text": "Enseña a tu pareja tu punto erógeno más sensible usando solo su dedo índice"
-  },
-  {
-    "id": 15,
-    "text": "Crea una 'ruta de besos' desde los labios hasta la entrepierna en el cuerpo de tu pareja"
-  },
-  {
-    "id": 16,
-    "text": "Demuestra cómo quieres que te sujeten durante el sexo mostrando la presión y posición exacta"
-  },
-  {
-    "id": 17,
-    "text": "Usando solo palabras, guía a tu pareja para que se masturbe exactamente como tú lo harías"
-  },
-  {
-    "id": 18,
-    "text": "Establece las 'reglas del aftergame': qué pasa cuando termine esta ronda del juego (premio/consecuencia íntima)"
-  },
-  {
-    "id": 19,
-    "text": "Con los ojos cerrados, identifica a tu pareja solo por el tacto de sus labios y luego demuestra cómo quieres que te besen"
-  },
-  {
-    "id": 20,
-    "text": "Crea un 'masaje de transición' de 2 minutos que comience en los hombros y termine en zonas más íntimas"
-  },
-  {
-    "id": 21,
-    "text": "Usando solo tu respiración en el oído de tu pareja, induce escalofríos eróticos por 60 segundos"
-  },
-  {
-    "id": 22,
-    "text": "Demuestra cómo te gusta que te quiten la ropa interior usando solo indicaciones verbales, sin usar las manos"
-  },
-  {
-    "id": 23,
-    "text": "Inventa un 'juego de seducción' donde cada prenda que se quiten otorgue un privilegio íntimo específico"
-  },
-  {
-    "id": 24,
-    "text": "Crea una 'narrativa íntima' describiendo exactamente cómo será vuestra próxima hora juntos, minuto a minuto"
-  },
-  {
-    "id": 25,
-    "text": "Enseña a tu pareja tres tipos diferentes de caricias y en qué momento del acto sexual usaría cada una"
-  },
-  {
-    "id": 26,
-    "text": "Demuestra la presión exacta que quieres en tu nuca durante el sexo oral usando la mano de tu pareja"
-  },
-  {
-    "id": 27,
-    "text": "Crea un 'diccionario íntimo' con 5 palabras clave que indicarán vuestros deseos durante la noche"
-  },
-  {
-    "id": 28,
-    "text": "Con movimientos de baile lento, muestra el ritmo que quieres para la penetración inicial"
-  },
-  {
-    "id": 29,
-    "text": "Enseña cómo te gusta que te sujeten de las caderas durante las posiciones por detrás"
-  },
-  {
-    "id": 30,
-    "text": "Crea un 'circuito de placer' en tu cuerpo que tu pareja debe seguir con sus manos en menos de 3 minutos"
-  },
-  {
-    "id": 31,
-    "text": "Usando solo la punta de los dedos, enseña los patrones de movimiento que más te excitan en tus zonas erógenas"
-  },
-  {
-    "id": 32,
-    "text": "Con una cereza en la boca, ofrece el tallo a tu pareja para que lo jale con sus dientes (sin usar manos)"
-  },
-  {
-    "id": 33,
-    "text": "Enseña a tu pareja exactamente cómo te gusta que te muerdan suavemente en diferentes partes del cuerpo"
-  },
-  {
-    "id": 34,
-    "text": "Con los ojos vendados, identifica a tu pareja solo por el tacto de su espalda"
-  },
-  {
-    "id": 35,
-    "text": "Crea un 'juego de roles' donde uno es maestro/a y el otro/a alumno/a en una 'lección de intimidad'"
-  },
-  {
-    "id": 36,
-    "text": "Usando solo tu aliento en el cuello de tu pareja, crea un patrón que siga con sus besos"
-  },
-  {
-    "id": 37,
-    "text": "Demuestra cómo te gusta que te sujeten del cabello durante momentos de intensidad"
-  },
-  {
-    "id": 38,
-    "text": "Con un hilo o cordón, crea un 'mapa de zonas erógenas' en el cuerpo de tu pareja"
-  },
-  {
-    "id": 39,
-    "text": "Invéntate un susurro que signifique 'quiero más' y otro que signifique 'más despacio'"
-  },
-  {
-    "id": 40,
-    "text": "Con una venda en los ojos, deja que tu pareja use solo sus labios para guiarte a través de su cuerpo"
-  },
-  {
-    "id": 41,
-    "text": "Crea una 'secuencia de 5 toques' que tu pareja debe memorizar y repetir en ti"
-  },
-  {
-    "id": 42,
-    "text": "Usando solo dos dedos, enseña la presión exacta que quieres en tus puntos más sensibles"
-  },
-  {
-    "id": 43,
-    "text": "Inventa un 'código de miradas' para comunicar deseos íntimos sin palabras"
-  },
-  {
-    "id": 44,
-    "text": "Con una fruta pequeña, demuestra el ritmo que prefieres para los preliminares"
-  },
-  {
-    "id": 45,
-    "text": "Enseña cómo te gusta que alternen entre caricias suaves y toques más firmes"
-  },
-  {
-    "id": 46,
-    "text": "Crea una 'narrativa erótica' guiando a tu pareja con palabras sobre qué hacer a continuación"
-  },
-  {
-    "id": 47,
-    "text": "Con una bufanda, demuestra cómo te gustaría que te vendaran los ojos suavemente"
-  },
-  {
-    "id": 48,
-    "text": "Inventa un 'juego de poder' donde uno da órdenes íntimas y el otro las sigue al pie de la letra"
-  },
-  {
-    "id": 49,
-    "text": "Usando solo tu lengua, escribe una letra en la piel de tu pareja y que adivine cuál es"
-  },
-  {
-    "id": 50,
-    "text": "Demuestra la diferencia exacta entre 'acariciar' y 'tocar' según tus preferencias"
-  },
-  {
-    "id": 51,
-    "text": "Crea un 'ritual de inicio' de 3 acciones que siempre harán antes de pasar a la intimidad"
-  },
-  {
-    "id": 52,
-    "text": "Con los ojos cerrados, guía la mano de tu pareja para que te toque exactamente como quieres"
-  },
-  {
-    "id": 53,
-    "text": "Inventa una 'señal de seguridad' que cualquiera puede usar para pausar o detener el juego"
-  },
-  {
-    "id": 54,
-    "text": "Usando solo tu respiración, indica cuándo quieres que aumente o disminuya la intensidad"
-  },
-  {
-    "id": 55,
-    "text": "Demuestra cómo prefieres que te cambien de posición: rápido y decidido o lento y sensual"
-  },
-  {
-    "id": 56,
-    "text": "Crea un 'vocabulario íntimo' con 3 palabras inventadas para describir sensaciones"
-  },
-  {
-    "id": 57,
-    "text": "Con una uva, ofrécela a tu pareja de manera sensual sin usar las manos"
-  },
-  {
-    "id": 58,
-    "text": "Enseña la presión exacta que quieres en tu cintura durante las posiciones de dominación"
-  },
-  {
-    "id": 59,
-    "text": "Inventa un 'sistema de puntos' donde ciertas acciones ganan privilegios íntimos"
-  },
-  {
-    "id": 60,
-    "text": "Con movimientos de cadera, demuestra el ángulo que prefieres durante la penetración"
-  }
+  "Elige a alguien y enséñale exactamente cómo te gusta que te toquen, guiando su mano con instrucciones específicas",
+  "Intercambien una prenda íntima y úsenla como requisito para el siguiente nivel de intimidad",
+  "Crea un 'ritual de 3 pasos' para pasar del juego al sexo, y demuestra el primer paso ahora",
+  "Elige un objeto común de la habitación y conviértelo en juguete sexual con tu imaginación",
+  "Susurra al oído de tu pareja exactamente qué harás con su cuerpo cuando terminen de jugar",
+  "Demuestra con movimientos pélvicos el ritmo que quieres para la penetración o fricción",
+  "Quítate una prenda de ropa usando solo una mano, mostrando cómo lo harías como preludio sexual",
+  "Inventa un código de 3 gestos con las manos para usar durante el sexo (más rápido, más lento, cambiar posición)",
+  "Con una fruta, demuestra cómo te gusta que te den sexo oral",
+  "Elige una superficie en esta habitación y muestra cómo la usarías para tener relaciones",
+  "Crea una 'lista de deseos íntimos' de 3 cosas que quieres hacer antes de que amanezca",
+  "Con un cubo de hielo, demuestra en tu propio cuerpo dónde te gusta que te lo usen durante el sexo",
+  "Simula un orgasmo realista que dure exactamente 20 segundos, incluyendo respiración y movimientos",
+  "Enseña a tu pareja tu punto erógeno más sensible usando solo su dedo índice",
+  "Crea una 'ruta de besos' desde los labios hasta la entrepierna en el cuerpo de tu pareja",
+  "Demuestra cómo quieres que te sujeten durante el sexo mostrando la presión y posición exacta",
+  "Usando solo palabras, guía a tu pareja para que se masturbe exactamente como tú lo harías",
+  "Establece las 'reglas del aftergame': qué pasa cuando termine esta ronda del juego (premio/consecuencia íntima)",
+  "Con los ojos cerrados, identifica a tu pareja solo por el tacto de sus labios y luego demuestra cómo quieres que te besen",
+  "Crea un 'masaje de transición' de 2 minutos que comience en los hombros y termine en zonas más íntimas",
+  "Usando solo tu respiración en el oído de tu pareja, induce escalofríos eróticos por 60 segundos",
+  "Demuestra cómo te gusta que te quiten la ropa interior usando solo indicaciones verbales, sin usar las manos",
+  "Inventa un 'juego de seducción' donde cada prenda que se quiten otorgue un privilegio íntimo específico",
+  "Crea una 'narrativa íntima' describiendo exactamente cómo será vuestra próxima hora juntos, minuto a minuto",
+  "Enseña a tu pareja tres tipos diferentes de caricias y en qué momento del acto sexual usaría cada una",
+  "Demuestra la presión exacta que quieres en tu nuca durante el sexo oral usando la mano de tu pareja",
+  "Crea un 'diccionario íntimo' con 5 palabras clave que indicarán vuestros deseos durante la noche",
+  "Con movimientos de baile lento, muestra el ritmo que quieres para la penetración inicial",
+  "Enseña cómo te gusta que te sujeten de las caderas durante las posiciones por detrás",
+  "Crea un 'circuito de placer' en tu cuerpo que tu pareja debe seguir con sus manos en menos de 3 minutos",
+  "Usando solo la punta de los dedos, enseña los patrones de movimiento que más te excitan en tus zonas erógenas",
+  "Con una cereza en la boca, ofrece el tallo a tu pareja para que lo jale con sus dientes (sin usar manos)",
+  "Enseña a tu pareja exactamente cómo te gusta que te muerdan suavemente en diferentes partes del cuerpo",
+  "Con los ojos vendados, identifica a tu pareja solo por el tacto de su espalda",
+  "Crea un 'juego de roles' donde uno es maestro/a y el otro/a alumno/a en una 'lección de intimidad'",
+  "Usando solo tu aliento en el cuello de tu pareja, crea un patrón que siga con sus besos",
+  "Demuestra cómo te gusta que te sujeten del cabello durante momentos de intensidad",
+  "Con un hilo o cordón, crea un 'mapa de zonas erógenas' en el cuerpo de tu pareja",
+  "Invéntate un susurro que signifique 'quiero más' y otro que signifique 'más despacio'",
+  "Con una venda en los ojos, deja que tu pareja use solo sus labios para guiarte a través de su cuerpo",
+  "Crea una 'secuencia de 5 toques' que tu pareja debe memorizar y repetir en ti",
+  "Usando solo dos dedos, enseña la presión exacta que quieres en tus puntos más sensibles",
+  "Inventa un 'código de miradas' para comunicar deseos íntimos sin palabras",
+  "Con una fruta pequeña, demuestra el ritmo que prefieres para los preliminares",
+  "Enseña cómo te gusta que alternen entre caricias suaves y toques más firmes",
+  "Crea una 'narrativa erótica' guiando a tu pareja con palabras sobre qué hacer a continuación",
+  "Con una bufanda, demuestra cómo te gustaría que te vendaran los ojos suavemente",
+  "Inventa un 'juego de poder' donde uno da órdenes íntimas y el otro las sigue al pie de la letra",
+  "Usando solo tu lengua, escribe una letra en la piel de tu pareja y que adivine cuál es",
+  "Demuestra la diferencia exacta entre 'acariciar' y 'tocar' según tus preferencias",
+  "Crea un 'ritual de inicio' de 3 acciones que siempre harán antes de pasar a la intimidad",
+  "Con los ojos cerrados, guía la mano de tu pareja para que te toque exactamente como quieres",
+  "Inventa una 'señal de seguridad' que cualquiera puede usar para pausar o detener el juego",
+  "Usando solo tu respiración, indica cuándo quieres que aumente o disminuya la intensidad",
+  "Demuestra cómo prefieres que te cambien de posición: rápido y decidido o lento y sensual",
+  "Crea un 'vocabulario íntimo' con 3 palabras inventadas para describir sensaciones",
+  "Con una uva, ofrécela a tu pareja de manera sensual sin usar las manos",
+  "Enseña la presión exacta que quieres en tu cintura durante las posiciones de dominación",
+  "Inventa un 'sistema de puntos' donde ciertas acciones ganan privilegios íntimos",
+  "Con movimientos de cadera, demuestra el ángulo que prefieres durante la penetración"
 ]

--- a/src/data/retos/extremo-verdad.json
+++ b/src/data/retos/extremo-verdad.json
@@ -1,242 +1,62 @@
 [
-  {
-    "id": 1,
-    "text": "¿Qué instrucción sexual específica y explícita le darías a alguien aquí para que te haga llegar al orgasmo más rápido?"
-  },
-  {
-    "id": 2,
-    "text": "Describe exactamente cómo te gustaría que te desvistan esta noche, detallando qué prenda quitarías última y por qué esa te excita especialmente"
-  },
-  {
-    "id": 3,
-    "text": "¿En qué parte íntima de mi cuerpo te gustaría dejar una marca de amor que solo nosotros podamos ver y tocar?"
-  },
-  {
-    "id": 4,
-    "text": "Si tuvieras que elegir un lugar en esta habitación para tener relaciones ahora mismo, ¿dónde sería y en qué posición comenzaríamos?"
-  },
-  {
-    "id": 5,
-    "text": "¿Qué gemido o quejido mío te excita tanto que pedirías que lo repitiera durante todo el acto sexual?"
-  },
-  {
-    "id": 6,
-    "text": "Si esta fuera nuestra última noche juntos, ¿qué fantasía sexual prohibida me pedirías que cumpliera contigo?"
-  },
-  {
-    "id": 7,
-    "text": "¿Qué juguete sexual específico te gustaría que usáramos juntos y cómo lo implementarías en cada parte de mi cuerpo?"
-  },
-  {
-    "id": 8,
-    "text": "Describe el ritmo exacto que más te excita cuando estamos teniendo relaciones, desde el inicio hasta el clímax"
-  },
-  {
-    "id": 9,
-    "text": "¿Qué zona erógena de tu cuerpo quieres que bese primero cuando pasemos a la intimidad después de este juego?"
-  },
-  {
-    "id": 10,
-    "text": "Si pudieras controlar mi cuerpo por 5 minutos en la intimidad, ¿qué me harías hacer exactamente y en qué orden?"
-  },
-  {
-    "id": 11,
-    "text": "¿Qué palabras obscenas o frase excitante quieres que te susurre al oído cuando estemos a punto de llegar al clímax juntos?"
-  },
-  {
-    "id": 12,
-    "text": "¿En qué posición quieres que terminemos esta noche cuando el juego se convierta en realidad?"
-  },
-  {
-    "id": 13,
-    "text": "¿Qué límite sexual personal te gustaría que rompiéramos juntos esta noche y por qué?"
-  },
-  {
-    "id": 14,
-    "text": "Describe con detalle cómo te gustaría que comenzara el sexo oral entre nosotros, incluyendo los primeros contactos"
-  },
-  {
-    "id": 15,
-    "text": "¿Qué temperatura (calor/frío) te gustaría incorporar en nuestra intimidad y en qué partes de nuestros cuerpos?"
-  },
-  {
-    "id": 16,
-    "text": "Si tuvieras que elegir entre mis manos, mi boca o mi entrepierna para tu placer exclusivo, ¿cuál elegirías y qué harías con ella?"
-  },
-  {
-    "id": 17,
-    "text": "¿Qué prenda de mi ropa quieres rasgar cuando pasemos al acto y por qué esa te resulta especialmente excitante?"
-  },
-  {
-    "id": 18,
-    "text": "¿A qué hora de la noche prefieres tener relaciones y qué tiene de especial ese momento para tu excitación?"
-  },
-  {
-    "id": 19,
-    "text": "¿Qué tipo de dominio o sumisión te excitaría experimentar conmigo esta noche y qué límites cruzaríamos?"
-  },
-  {
-    "id": 20,
-    "text": "Si este juego termina en nuestra cama, ¿qué promesa sexual explícita me haces para asegurar que sea la noche más memorable?"
-  },
-  {
-    "id": 21,
-    "text": "¿Qué parte de tu cuerpo quieres que explore con mi boca primero cuando pasemos a la intimidad y por qué ahí específicamente?"
-  },
-  {
-    "id": 22,
-    "text": "Si pudieras elegir un aceite o lubricante para usar en nuestra piel esta noche, ¿cuál sería y cómo lo aplicarías en mis zonas más sensibles?"
-  },
-  {
-    "id": 23,
-    "text": "¿Qué fantasía de poder te excita más: ser completamente dominado/a o tomar el control total, y qué harías en cada caso?"
-  },
-  {
-    "id": 24,
-    "text": "Describe el tipo de mordiscos, succiones o caricias fuertes que más te excitan y en qué partes específicas del cuerpo los quieres"
-  },
-  {
-    "id": 25,
-    "text": "¿Qué juguete sexual mío te gustaría controlar remotamente mientras estamos en público antes de llegar a casa, y en qué intensidad?"
-  },
-  {
-    "id": 26,
-    "text": "Si tuvieras que grabar un video íntimo nuestro, ¿qué escena específica querrías capturar, desde qué ángulo y con qué sonidos?"
-  },
-  {
-    "id": 27,
-    "text": "¿Qué parte de mi sudor, aroma natural o fluidos te excita más durante el sexo y por qué te vuelve loco/a?"
-  },
-  {
-    "id": 28,
-    "text": "Describe exactamente cómo te gusta que te sujeten del cabello durante el sexo intenso y qué palabras quieres escuchar en ese momento"
-  },
-  {
-    "id": 29,
-    "text": "¿Qué posición sexual nos permitiría mantener contacto visual constante y cómo intensificaría eso tu placer hasta el límite?"
-  },
-  {
-    "id": 30,
-    "text": "Si pudiéramos incorporar comida en nuestra intimidad, ¿qué alimento usarías, en qué parte de mi cuerpo y cómo lo lamerías después?"
-  },
-  {
-    "id": 31,
-    "text": "¿Qué sonido de mi respiración jadeante o latidos acelerados quieres escuchar contra tu oído durante el acto más intenso?"
-  },
-  {
-    "id": 32,
-    "text": "Describe la presión exacta que quieres que use con mis manos cuando te toque durante el orgasmo y dónde quieres que termine"
-  },
-  {
-    "id": 33,
-    "text": "¿Qué parte de esta habitación convertirías en nuestro 'rincón íntimo' y cómo lo prepararías para una sesión de sexo salvaje?"
-  },
-  {
-    "id": 34,
-    "text": "Si pudiéramos tener sexo en un lugar con riesgo de ser vistos, ¿dónde sería, qué nos haría más excitante y qué posición usaríamos?"
-  },
-  {
-    "id": 35,
-    "text": "¿Qué tipo de dirty talk específico y explícito quieres que use contigo cuando estés a punto de venirte, incluyendo nombres y verbos?"
-  },
-  {
-    "id": 36,
-    "text": "Describe cómo te gusta que cambie el ritmo sexual justo antes de que alcances el orgasmo y qué debo hacer exactamente en ese momento"
-  },
-  {
-    "id": 37,
-    "text": "¿Qué juguete de bondage ligero te gustaría que usáramos, cómo limitaría tu movimiento y qué haría yo con tu cuerpo inmovilizado?"
-  },
-  {
-    "id": 38,
-    "text": "Si pudieras elegir una música de fondo para nuestro encuentro íntimo, ¿qué canción sería, a qué volumen y por qué esa te excita?"
-  },
-  {
-    "id": 39,
-    "text": "¿Qué parte de mi cuerpo quieres sentir más cerca del tuyo durante la penetración o fricción, y cómo quieres que roce contra ti?"
-  },
-  {
-    "id": 40,
-    "text": "Describe el momento exacto en que sabes que estás lista/o para pasar del juego al sexo real y qué señal me darías"
-  },
-  {
-    "id": 41,
-    "text": "¿Qué fantasía sexual que nunca has confesado te gustaría realizar conmigo esta misma noche, detallando cada paso?"
-  },
-  {
-    "id": 42,
-    "text": "Describe cómo te gustaría que te sorprendiera sexualmente en un lugar inesperado de esta casa, incluyendo qué haría primero"
-  },
-  {
-    "id": 43,
-    "text": "¿Qué parte de mi cuerpo quieres cubrir con tus besos primero y cuál guardarías para el momento del clímax máximo?"
-  },
-  {
-    "id": 44,
-    "text": "Si tuvieras que elegir entre sexo lento y sensual vs rápido y salvaje para comenzar, ¿cuál elegirías y cómo sería el primer contacto?"
-  },
-  {
-    "id": 45,
-    "text": "¿Qué juguete para parejas nos haría llegar al orgasmo simultáneo y cómo lo usaríamos en nuestros cuerpos?"
-  },
-  {
-    "id": 46,
-    "text": "Describe la presión exacta que quieres en tu cuello durante los momentos más intensos del sexo y qué permiso me das"
-  },
-  {
-    "id": 47,
-    "text": "¿En qué posición quieres estar cuando te penetre/estimule por primera vez esta noche y qué quieres que haga con mis manos?"
-  },
-  {
-    "id": 48,
-    "text": "Si pudiéramos agregar un tercero a nuestra intimidad, ¿qué características tendría y qué rol jugaría contigo?"
-  },
-  {
-    "id": 49,
-    "text": "¿Qué parte de tu cuerpo quieres que marque con mis dientes como señal de pertenencia y por qué ese lugar específico?"
-  },
-  {
-    "id": 50,
-    "text": "Describe exactamente cómo quieres que te estimule manualmente hasta el borde del orgasmo antes de cualquier penetración"
-  },
-  {
-    "id": 51,
-    "text": "¿Qué ropa interior mía te excita más que me quite y qué harías con ella durante el acto sexual?"
-  },
-  {
-    "id": 52,
-    "text": "Si pudieras diseñar el orgasmo perfecto conmigo, ¿qué incluiría de principio a fin, detallando cada sensación?"
-  },
-  {
-    "id": 53,
-    "text": "¿Qué palabra obscena quieres que grite cuando llegues al clímax y cuál quieres escuchar de mi boca en ese momento?"
-  },
-  {
-    "id": 54,
-    "text": "Describe cómo te gustaría que usara mis pies/piernas en tu estimulación sexual si fuera tu fantasía secreta"
-  },
-  {
-    "id": 55,
-    "text": "¿Qué líquido corporal mío te excita más y dónde te gustaría sentirlo o probarlo durante nuestra intimidad?"
-  },
-  {
-    "id": 56,
-    "text": "Si el sexo oral fuera el único acto permitido esta noche, ¿cómo querrías recibirlo y darlo, detallando minutos y técnicas?"
-  },
-  {
-    "id": 57,
-    "text": "¿Qué parte de mi piel quieres lamer durante el sexo y cómo continuarías desde ahí hacia otras zonas erógenas?"
-  },
-  {
-    "id": 58,
-    "text": "Describe el momento exacto en que quieres que cambiemos de posición durante el acto y a cuál pasaríamos"
-  },
-  {
-    "id": 59,
-    "text": "¿Qué objeto no sexual de esta habitación usarías en nuestra intimidad y cómo lo implementarías para mayor placer?"
-  },
-  {
-    "id": 60,
-    "text": "Si este fuera nuestro último encuentro sexual, ¿qué recuerdo físico y sensación específica querrías que quedara grabado en tu cuerpo y memoria para siempre?"
-  }
+  "¿Qué instrucción sexual específica y explícita le darías a alguien aquí para que te haga llegar al orgasmo más rápido?",
+  "Describe exactamente cómo te gustaría que te desvistan esta noche, detallando qué prenda quitarías última y por qué esa te excita especialmente",
+  "¿En qué parte íntima de mi cuerpo te gustaría dejar una marca de amor que solo nosotros podamos ver y tocar?",
+  "Si tuvieras que elegir un lugar en esta habitación para tener relaciones ahora mismo, ¿dónde sería y en qué posición comenzaríamos?",
+  "¿Qué gemido o quejido mío te excita tanto que pedirías que lo repitiera durante todo el acto sexual?",
+  "Si esta fuera nuestra última noche juntos, ¿qué fantasía sexual prohibida me pedirías que cumpliera contigo?",
+  "¿Qué juguete sexual específico te gustaría que usáramos juntos y cómo lo implementarías en cada parte de mi cuerpo?",
+  "Describe el ritmo exacto que más te excita cuando estamos teniendo relaciones, desde el inicio hasta el clímax",
+  "¿Qué zona erógena de tu cuerpo quieres que bese primero cuando pasemos a la intimidad después de este juego?",
+  "Si pudieras controlar mi cuerpo por 5 minutos en la intimidad, ¿qué me harías hacer exactamente y en qué orden?",
+  "¿Qué palabras obscenas o frase excitante quieres que te susurre al oído cuando estemos a punto de llegar al clímax juntos?",
+  "¿En qué posición quieres que terminemos esta noche cuando el juego se convierta en realidad?",
+  "¿Qué límite sexual personal te gustaría que rompiéramos juntos esta noche y por qué?",
+  "Describe con detalle cómo te gustaría que comenzara el sexo oral entre nosotros, incluyendo los primeros contactos",
+  "¿Qué temperatura (calor/frío) te gustaría incorporar en nuestra intimidad y en qué partes de nuestros cuerpos?",
+  "Si tuvieras que elegir entre mis manos, mi boca o mi entrepierna para tu placer exclusivo, ¿cuál elegirías y qué harías con ella?",
+  "¿Qué prenda de mi ropa quieres rasgar cuando pasemos al acto y por qué esa te resulta especialmente excitante?",
+  "¿A qué hora de la noche prefieres tener relaciones y qué tiene de especial ese momento para tu excitación?",
+  "¿Qué tipo de dominio o sumisión te excitaría experimentar conmigo esta noche y qué límites cruzaríamos?",
+  "Si este juego termina en nuestra cama, ¿qué promesa sexual explícita me haces para asegurar que sea la noche más memorable?",
+  "¿Qué parte de tu cuerpo quieres que explore con mi boca primero cuando pasemos a la intimidad y por qué ahí específicamente?",
+  "Si pudieras elegir un aceite o lubricante para usar en nuestra piel esta noche, ¿cuál sería y cómo lo aplicarías en mis zonas más sensibles?",
+  "¿Qué fantasía de poder te excita más: ser completamente dominado/a o tomar el control total, y qué harías en cada caso?",
+  "Describe el tipo de mordiscos, succiones o caricias fuertes que más te excitan y en qué partes específicas del cuerpo los quieres",
+  "¿Qué juguete sexual mío te gustaría controlar remotamente mientras estamos en público antes de llegar a casa, y en qué intensidad?",
+  "Si tuvieras que grabar un video íntimo nuestro, ¿qué escena específica querrías capturar, desde qué ángulo y con qué sonidos?",
+  "¿Qué parte de mi sudor, aroma natural o fluidos te excita más durante el sexo y por qué te vuelve loco/a?",
+  "Describe exactamente cómo te gusta que te sujeten del cabello durante el sexo intenso y qué palabras quieres escuchar en ese momento",
+  "¿Qué posición sexual nos permitiría mantener contacto visual constante y cómo intensificaría eso tu placer hasta el límite?",
+  "Si pudiéramos incorporar comida en nuestra intimidad, ¿qué alimento usarías, en qué parte de mi cuerpo y cómo lo lamerías después?",
+  "¿Qué sonido de mi respiración jadeante o latidos acelerados quieres escuchar contra tu oído durante el acto más intenso?",
+  "Describe la presión exacta que quieres que use con mis manos cuando te toque durante el orgasmo y dónde quieres que termine",
+  "¿Qué parte de esta habitación convertirías en nuestro 'rincón íntimo' y cómo lo prepararías para una sesión de sexo salvaje?",
+  "Si pudiéramos tener sexo en un lugar con riesgo de ser vistos, ¿dónde sería, qué nos haría más excitante y qué posición usaríamos?",
+  "¿Qué tipo de dirty talk específico y explícito quieres que use contigo cuando estés a punto de venirte, incluyendo nombres y verbos?",
+  "Describe cómo te gusta que cambie el ritmo sexual justo antes de que alcances el orgasmo y qué debo hacer exactamente en ese momento",
+  "¿Qué juguete de bondage ligero te gustaría que usáramos, cómo limitaría tu movimiento y qué haría yo con tu cuerpo inmovilizado?",
+  "Si pudieras elegir una música de fondo para nuestro encuentro íntimo, ¿qué canción sería, a qué volumen y por qué esa te excita?",
+  "¿Qué parte de mi cuerpo quieres sentir más cerca del tuyo durante la penetración o fricción, y cómo quieres que roce contra ti?",
+  "Describe el momento exacto en que sabes que estás lista/o para pasar del juego al sexo real y qué señal me darías",
+  "¿Qué fantasía sexual que nunca has confesado te gustaría realizar conmigo esta misma noche, detallando cada paso?",
+  "Describe cómo te gustaría que te sorprendiera sexualmente en un lugar inesperado de esta casa, incluyendo qué haría primero",
+  "¿Qué parte de mi cuerpo quieres cubrir con tus besos primero y cuál guardarías para el momento del clímax máximo?",
+  "Si tuvieras que elegir entre sexo lento y sensual vs rápido y salvaje para comenzar, ¿cuál elegirías y cómo sería el primer contacto?",
+  "¿Qué juguete para parejas nos haría llegar al orgasmo simultáneo y cómo lo usaríamos en nuestros cuerpos?",
+  "Describe la presión exacta que quieres en tu cuello durante los momentos más intensos del sexo y qué permiso me das",
+  "¿En qué posición quieres estar cuando te penetre/estimule por primera vez esta noche y qué quieres que haga con mis manos?",
+  "Si pudiéramos agregar un tercero a nuestra intimidad, ¿qué características tendría y qué rol jugaría contigo?",
+  "¿Qué parte de tu cuerpo quieres que marque con mis dientes como señal de pertenencia y por qué ese lugar específico?",
+  "Describe exactamente cómo quieres que te estimule manualmente hasta el borde del orgasmo antes de cualquier penetración",
+  "¿Qué ropa interior mía te excita más que me quite y qué harías con ella durante el acto sexual?",
+  "Si pudieras diseñar el orgasmo perfecto conmigo, ¿qué incluiría de principio a fin, detallando cada sensación?",
+  "¿Qué palabra obscena quieres que grite cuando llegues al clímax y cuál quieres escuchar de mi boca en ese momento?",
+  "Describe cómo te gustaría que usara mis pies/piernas en tu estimulación sexual si fuera tu fantasía secreta",
+  "¿Qué líquido corporal mío te excita más y dónde te gustaría sentirlo o probarlo durante nuestra intimidad?",
+  "Si el sexo oral fuera el único acto permitido esta noche, ¿cómo querrías recibirlo y darlo, detallando minutos y técnicas?",
+  "¿Qué parte de mi piel quieres lamer durante el sexo y cómo continuarías desde ahí hacia otras zonas erógenas?",
+  "Describe el momento exacto en que quieres que cambiemos de posición durante el acto y a cuál pasaríamos",
+  "¿Qué objeto no sexual de esta habitación usarías en nuestra intimidad y cómo lo implementarías para mayor placer?",
+  "Si este fuera nuestro último encuentro sexual, ¿qué recuerdo físico y sensación específica querrías que quedara grabado en tu cuerpo y memoria para siempre?"
 ]

--- a/src/data/retos/parejas-reto.json
+++ b/src/data/retos/parejas-reto.json
@@ -1,218 +1,56 @@
 [
-  {
-    "id": 1,
-    "text": "Dale un beso en la mano a tu pareja como un caballero/dama."
-  },
-  {
-    "id": 2,
-    "text": "Susúrrame algo al oído que me haga sonreír."
-  },
-  {
-    "id": 3,
-    "text": "Haz un masaje de 1 minuto en los hombros de tu pareja."
-  },
-  {
-    "id": 4,
-    "text": "Imita mi forma de caminar."
-  },
-  {
-    "id": 5,
-    "text": "Dime un piropo cursi sin reírte."
-  },
-  {
-    "id": 6,
-    "text": "Dame un abrazo por 10 segundos sin soltarme."
-  },
-  {
-    "id": 7,
-    "text": "Dibuja un retrato rápido de tu pareja."
-  },
-  {
-    "id": 8,
-    "text": "Baila con tu pareja como si fuera tu primera cita."
-  },
-  {
-    "id": 9,
-    "text": "Dime tres cosas que te gusten de mí (sin repetir)."
-  },
-  {
-    "id": 10,
-    "text": "Dale un beso a tu pareja en la parte de su cuerpo que más te guste."
-  },
-  {
-    "id": 11,
-    "text": "Escribe un mensaje de amor en la espalda de tu pareja con tu dedo y que adivine qué dice."
-  },
-  {
-    "id": 12,
-    "text": "Haz un role-play: actúa cómo sería nuestra primera pelea si nos hubiéramos conocido en el siglo XIX."
-  },
-  {
-    "id": 13,
-    "text": "Dí algo que siempre hayas querido decirme... pero usando solo emojis (el otro debe adivinar)."
-  },
-  {
-    "id": 14,
-    "text": "Tómate una foto juntos haciendo muecas exageradas y guárdala como fondo de pantalla por un día."
-  },
-  {
-    "id": 15,
-    "text": "Inventa un apodo ridículo para tu pareja y úsalo sin reírte durante los próximos 5 minutos."
-  },
-  {
-    "id": 16,
-    "text": "Con los ojos vendados, reconoce a tu pareja solo oliendo su perfume o loción."
-  },
-  {
-    "id": 17,
-    "text": "Escribe un poema de 4 líneas sobre tu pareja usando solo palabras que empiecen con la primera letra de su nombre."
-  },
-  {
-    "id": 18,
-    "text": "Haz un striptease lento... pero quitándote capas de ropa exageradas (bufanda, chaqueta, etc.)."
-  },
-  {
-    "id": 19,
-    "text": "Con un hielo en la boca, dibuja un corazón en el cuello de tu pareja."
-  },
-  {
-    "id": 20,
-    "text": "Graba un video de 10 segundos imitando nuestro primer beso (puede ser exagerado)."
-  },
-  {
-    "id": 21,
-    "text": "Dale a tu pareja un 'masaje' solo con codos y nariz (sin usar manos)."
-  },
-  {
-    "id": 22,
-    "text": "Susurra una fantasía romántica (no sexual) que tengas para nuestra relación."
-  },
-  {
-    "id": 23,
-    "text": "Construye una 'escultura' con 3 objetos cercanos que represente nuestra relación."
-  },
-  {
-    "id": 24,
-    "text": "Dale un pico por cada año de relación que tengan."
-  },
-  {
-    "id": 25,
-    "text": "Mírame a los ojos sin hablar ni reírte durante 30 segundos (el que rompa el contacto pierde)."
-  },
-  {
-    "id": 26,
-    "text": "Con los ojos cerrados, alimenta a tu pareja con algo dulce y que adivine qué es (tienes 3 intentos)."
-  },
-  {
-    "id": 27,
-    "text": "Crea una 'cápsula del tiempo' con 3 objetos cercanos que representen nuestra relación y entiérrala simbólicamente."
-  },
-  {
-    "id": 28,
-    "text": "Con una hoja en la boca, declara tu amor como si fueras un personaje de telenovela (¡sin reírte!)."
-  },
-  {
-    "id": 29,
-    "text": "Dibuja con lápiz labial un mensaje secreto en el espejo para que tu pareja lo encuentre mañana."
-  },
-  {
-    "id": 30,
-    "text": "Haz un 'tráiler cinematográfico' narrando nuestra relación en 30 segundos (usa objetos como micrófono)."
-  },
-  {
-    "id": 31,
-    "text": "Con las manos atadas a la espalda, intenta desabrochar un botón de la camisa de tu pareja (¡solo con los dientes!)."
-  },
-  {
-    "id": 32,
-    "text": "Inventa un baile tonto que represente 'nuestro tema' y enséñaselo a tu pareja."
-  },
-  {
-    "id": 33,
-    "text": "Con una venda en los ojos, reconoce a tu pareja solo tocando sus manos (tienes 2 intentos)."
-  },
-  {
-    "id": 34,
-    "text": "Escribe con chocolate en su espalda lo que más te gusta de vuestra relación y luego... ¡límpialo con un beso!"
-  },
-  {
-    "id": 35,
-    "text": "Graba un mensaje de voz imitando a un anuncio de radio sobre 'el producto perfecto' (¡tu pareja!)."
-  },
-  {
-    "id": 36,
-    "text": "Con una uva en la boca (sin manos), pásasela a tu pareja en un 'beso estilo Hollywood'"
-  },
-  {
-    "id": 37,
-    "text": "Crea una canción tonta de 30 segundos sobre vuestra relación usando solo sonidos de animales"
-  },
-  {
-    "id": 38,
-    "text": "Con los ojos vendados, reconoce a tu pareja solo por su forma de besarte en la mano"
-  },
-  {
-    "id": 39,
-    "text": "Escribe un mensaje de amor en el brazo de tu pareja con protector solar y espera a que se broncee"
-  },
-  {
-    "id": 40,
-    "text": "Hagan un 'retrato hablado' alternando quien dibuja cada rasgo facial sin comunicarse"
-  },
-  {
-    "id": 41,
-    "text": "Con una cuchara en la boca, intenten alimentarse mutuamente sin derramar nada"
-  },
-  {
-    "id": 42,
-    "text": "Recreen su primera foto juntos con la expresión facial más exagerada posible"
-  },
-  {
-    "id": 43,
-    "text": "Inventen un apretón de manos secreto que represente su relación"
-  },
-  {
-    "id": 44,
-    "text": "Con las manos atadas con una corbata/cinturón, intenten envolver un regalo juntos"
-  },
-  {
-    "id": 45,
-    "text": "Graba un video de 15 segundos imitando el estilo de baile favorito de tu pareja"
-  },
-  {
-    "id": 46,
-    "text": "Dale a tu pareja un beso en el lugar más inesperado de su cuerpo"
-  },
-  {
-    "id": 47,
-    "text": "Susurra al oído de tu pareja lo que más te gusta hacer con ella"
-  },
-  {
-    "id": 48,
-    "text": "Haz un masaje sensual en los pies de tu pareja por 2 minutos"
-  },
-  {
-    "id": 49,
-    "text": "Dale de comer a tu pareja con los ojos vendados"
-  },
-  {
-    "id": 50,
-    "text": "Dile a tu pareja tres cosas que nunca le has dicho antes"
-  },
-  {
-    "id": 51,
-    "text": "Bailen una canción lenta abrazados sin separarse"
-  },
-  {
-    "id": 52,
-    "text": "Escribe con tu dedo una palabra de amor en la espalda de tu pareja"
-  },
-  {
-    "id": 53,
-    "text": "Dale un beso que dure exactamente 10 segundos"
-  },
-  {
-    "id": 54,
-    "text": "Cuéntale a tu pareja tu fantasía romántica más dulce"
-  }
+  "Dale un beso en la mano a tu pareja como un caballero/dama.",
+  "Susúrrame algo al oído que me haga sonreír.",
+  "Haz un masaje de 1 minuto en los hombros de tu pareja.",
+  "Imita mi forma de caminar.",
+  "Dime un piropo cursi sin reírte.",
+  "Dame un abrazo por 10 segundos sin soltarme.",
+  "Dibuja un retrato rápido de tu pareja.",
+  "Baila con tu pareja como si fuera tu primera cita.",
+  "Dime tres cosas que te gusten de mí (sin repetir).",
+  "Dale un beso a tu pareja en la parte de su cuerpo que más te guste.",
+  "Escribe un mensaje de amor en la espalda de tu pareja con tu dedo y que adivine qué dice.",
+  "Haz un role-play: actúa cómo sería nuestra primera pelea si nos hubiéramos conocido en el siglo XIX.",
+  "Dí algo que siempre hayas querido decirme... pero usando solo emojis (el otro debe adivinar).",
+  "Tómate una foto juntos haciendo muecas exageradas y guárdala como fondo de pantalla por un día.",
+  "Inventa un apodo ridículo para tu pareja y úsalo sin reírte durante los próximos 5 minutos.",
+  "Con los ojos vendados, reconoce a tu pareja solo oliendo su perfume o loción.",
+  "Escribe un poema de 4 líneas sobre tu pareja usando solo palabras que empiecen con la primera letra de su nombre.",
+  "Haz un striptease lento... pero quitándote capas de ropa exageradas (bufanda, chaqueta, etc.).",
+  "Con un hielo en la boca, dibuja un corazón en el cuello de tu pareja.",
+  "Graba un video de 10 segundos imitando nuestro primer beso (puede ser exagerado).",
+  "Dale a tu pareja un 'masaje' solo con codos y nariz (sin usar manos).",
+  "Susurra una fantasía romántica (no sexual) que tengas para nuestra relación.",
+  "Construye una 'escultura' con 3 objetos cercanos que represente nuestra relación.",
+  "Dale un pico por cada año de relación que tengan.",
+  "Mírame a los ojos sin hablar ni reírte durante 30 segundos (el que rompa el contacto pierde).",
+  "Con los ojos cerrados, alimenta a tu pareja con algo dulce y que adivine qué es (tienes 3 intentos).",
+  "Crea una 'cápsula del tiempo' con 3 objetos cercanos que representen nuestra relación y entiérrala simbólicamente.",
+  "Con una hoja en la boca, declara tu amor como si fueras un personaje de telenovela (¡sin reírte!).",
+  "Dibuja con lápiz labial un mensaje secreto en el espejo para que tu pareja lo encuentre mañana.",
+  "Haz un 'tráiler cinematográfico' narrando nuestra relación en 30 segundos (usa objetos como micrófono).",
+  "Con las manos atadas a la espalda, intenta desabrochar un botón de la camisa de tu pareja (¡solo con los dientes!).",
+  "Inventa un baile tonto que represente 'nuestro tema' y enséñaselo a tu pareja.",
+  "Con una venda en los ojos, reconoce a tu pareja solo tocando sus manos (tienes 2 intentos).",
+  "Escribe con chocolate en su espalda lo que más te gusta de vuestra relación y luego... ¡límpialo con un beso!",
+  "Graba un mensaje de voz imitando a un anuncio de radio sobre 'el producto perfecto' (¡tu pareja!).",
+  "Con una uva en la boca (sin manos), pásasela a tu pareja en un 'beso estilo Hollywood'",
+  "Crea una canción tonta de 30 segundos sobre vuestra relación usando solo sonidos de animales",
+  "Con los ojos vendados, reconoce a tu pareja solo por su forma de besarte en la mano",
+  "Escribe un mensaje de amor en el brazo de tu pareja con protector solar y espera a que se broncee",
+  "Hagan un 'retrato hablado' alternando quien dibuja cada rasgo facial sin comunicarse",
+  "Con una cuchara en la boca, intenten alimentarse mutuamente sin derramar nada",
+  "Recreen su primera foto juntos con la expresión facial más exagerada posible",
+  "Inventen un apretón de manos secreto que represente su relación",
+  "Con las manos atadas con una corbata/cinturón, intenten envolver un regalo juntos",
+  "Graba un video de 15 segundos imitando el estilo de baile favorito de tu pareja",
+  "Dale a tu pareja un beso en el lugar más inesperado de su cuerpo",
+  "Susurra al oído de tu pareja lo que más te gusta hacer con ella",
+  "Haz un masaje sensual en los pies de tu pareja por 2 minutos",
+  "Dale de comer a tu pareja con los ojos vendados",
+  "Dile a tu pareja tres cosas que nunca le has dicho antes",
+  "Bailen una canción lenta abrazados sin separarse",
+  "Escribe con tu dedo una palabra de amor en la espalda de tu pareja",
+  "Dale un beso que dure exactamente 10 segundos",
+  "Cuéntale a tu pareja tu fantasía romántica más dulce"
 ]

--- a/src/data/retos/parejas-verdad.json
+++ b/src/data/retos/parejas-verdad.json
@@ -1,222 +1,62 @@
 [
-  {
-    "id": 1,
-    "text": "¿Qué fue lo primero que pensaste cuando me viste?"
-  },
-  {
-    "id": 2,
-    "text": "¿Qué es lo que más te molesta de mí?"
-  },
-  {
-    "id": 3,
-    "text": "¿Alguna vez has fantaseado con alguien más estando conmigo?"
-  },
-  {
-    "id": 4,
-    "text": "¿Qué es lo más loco que has hecho por amor?"
-  },
-  {
-    "id": 5,
-    "text": "¿Cuál ha sido nuestro peor momento juntos?"
-  },
-  {
-    "id": 6,
-    "text": "¿Qué cambiarías de nuestra relación?"
-  },
-  {
-    "id": 7,
-    "text": "¿Qué es lo más raro que te gusta de mí?"
-  },
-  {
-    "id": 8,
-    "text": "¿Alguna vez has revisado mi celular a escondidas?"
-  },
-  {
-    "id": 9,
-    "text": "¿Qué no sabes de mí pero te gustaría descubrir?"
-  },
-  {
-    "id": 10,
-    "text": "¿Qué mentira me has dicho?"
-  },
-  {
-    "id": 11,
-    "text": "¿Qué momento juntos te hizo sentir más orgullos@ de nuestra relación?"
-  },
-  {
-    "id": 12,
-    "text": "Si tuvieras que describir nuestra relación con una película, ¿cuál sería y por qué?"
-  },
-  {
-    "id": 13,
-    "text": "¿Qué hábito mío te encanta pero nunca me has dicho?"
-  },
-  {
-    "id": 14,
-    "text": "¿Qué canción asocias conmigo y por qué?"
-  },
-  {
-    "id": 15,
-    "text": "Si pudieras planear nuestra cita ideal, ¿qué incluiría (detalles específicos)?"
-  },
-  {
-    "id": 16,
-    "text": "¿Qué detalle pequeño mío te parece inexplicablemente sexy?"
-  },
-  {
-    "id": 17,
-    "text": "Si nuestra relación tuviera un soundtrack, ¿qué 3 canciones no podrían faltar y por qué?"
-  },
-  {
-    "id": 18,
-    "text": "¿Qué tradición curiosa te gustaría que empezáramos juntos?"
-  },
-  {
-    "id": 19,
-    "text": "¿Qué película o serie nos describe mejor como pareja?"
-  },
-  {
-    "id": 20,
-    "text": "¿Qué outfit mío te vuelve loc@ y por qué?"
-  },
-  {
-    "id": 21,
-    "text": "Si pudieras teleportarnos a cualquier lugar ahora mismo, ¿dónde iríamos y qué haríamos?"
-  },
-  {
-    "id": 22,
-    "text": "¿Qué frase o gesto mío te derrite incluso cuando estás enojad@?"
-  },
-  {
-    "id": 23,
-    "text": "¿Qué sueño o fantasía nuestra (no sexual) te gustaría cumplir este año?"
-  },
-  {
-    "id": 24,
-    "text": "¿Qué app o red social mía revisarías si tuvieras acceso libre (y por qué)?"
-  },
-  {
-    "id": 25,
-    "text": "Si mañana despertáramos intercambiando cuerpos, ¿qué sería lo primero que harías con el mío?"
-  },
-  {
-    "id": 26,
-    "text": "¿Qué parte de mi personalidad te sorprendió gratamente cuando empezamos a salir?"
-  },
-  {
-    "id": 27,
-    "text": "Si nuestra relación fuera un meme, ¿cuál sería y por qué?"
-  },
-  {
-    "id": 28,
-    "text": "¿Qué mentira piadosa me sigues diciendo para no herir mis sentimientos?"
-  },
-  {
-    "id": 29,
-    "text": "¿Qué cosa hago cuando creo que no estás mirando que te parece adorable?"
-  },
-  {
-    "id": 30,
-    "text": "Si tuvieras que describir nuestro primer beso con un título de película, ¿cuál sería?"
-  },
-  {
-    "id": 31,
-    "text": "¿Qué hábito mío has adoptado sin darte cuenta?"
-  },
-  {
-    "id": 32,
-    "text": "¿Qué apodo me pondrías si tuvieras que usarlo frente a mis amigos?"
-  },
-  {
-    "id": 33,
-    "text": "¿Qué momento nuestro te gustaría revivir en cámara lenta?"
-  },
-  {
-    "id": 34,
-    "text": "¿Qué canción de amor odias pero finges que te gusta porque a mí me encanta?"
-  },
-  {
-    "id": 35,
-    "text": "Si solo pudiéramos tener una foto juntos para el resto de nuestra vida, ¿cuál sería y por qué?"
-  },
-  {
-    "id": 36,
-    "text": "¿Qué momento cotidiano juntos (como lavar platos o hacer mercado) te parece inexplicablemente romántico?"
-  },
-  {
-    "id": 37,
-    "text": "Si nuestra relación tuviera un aroma, ¿qué olor sería y por qué?"
-  },
-  {
-    "id": 38,
-    "text": "¿Qué cosa que hago sin pensar te hace sentir más amado/a?"
-  },
-  {
-    "id": 39,
-    "text": "¿Qué error mío has aprendido a amar porque es parte de quién soy?"
-  },
-  {
-    "id": 40,
-    "text": "Si tuvieras que describir nuestro amor con un sabor de helado, ¿cuál sería y por qué?"
-  },
-  {
-    "id": 41,
-    "text": "¿Qué rasgo de personalidad mío te resultó chocante al principio pero ahora aprecias?"
-  },
-  {
-    "id": 42,
-    "text": "¿Qué promesa de pareja hemos roto que en realidad nos benefició?"
-  },
-  {
-    "id": 43,
-    "text": "Si pudiéramos intercambiar un talento o habilidad, ¿qué te gustaría que yo aprendiera de ti?"
-  },
-  {
-    "id": 44,
-    "text": "¿Qué tradición familiar mía te gustaría incorporar a nuestra relación?"
-  },
-  {
-    "id": 45,
-    "text": "Si nuestra relación fuera un libro, ¿qué capítulo estamos viviendo ahora y cómo terminaría la historia?"
-  },
-  {
-    "id": 46,
-    "text": "¿Cuál es tu recuerdo favorito de nosotros dos?"
-  },
-  {
-    "id": 47,
-    "text": "¿Qué es lo que más te atrae físicamente de mí?"
-  },
-  {
-    "id": 48,
-    "text": "¿Hay algo de mí que cambiarías si pudieras?"
-  },
-  {
-    "id": 49,
-    "text": "¿Cuál fue el momento en que supiste que me amabas?"
-  },
-  {
-    "id": 50,
-    "text": "¿Qué es lo más sexy que he hecho sin darme cuenta?"
-  },
-  {
-    "id": 51,
-    "text": "¿Cuál es tu mayor inseguridad en nuestra relación?"
-  },
-  {
-    "id": 52,
-    "text": "¿Qué es lo que más te gusta cuando hacemos el amor?"
-  },
-  {
-    "id": 53,
-    "text": "¿Cuál es tu lugar favorito para besarme?"
-  },
-  {
-    "id": 54,
-    "text": "¿Qué me dirías si supieras que mañana no nos volvemos a ver?"
-  },
-  {
-    "id": 55,
-    "text": "¿Cuál es tu sueño más grande para nuestro futuro juntos?"
-  }
+  "¿Qué fue lo primero que pensaste cuando me viste?",
+  "¿Qué es lo que más te molesta de mí?",
+  "¿Alguna vez has fantaseado con alguien más estando conmigo?",
+  "¿Qué es lo más loco que has hecho por amor?",
+  "¿Cuál ha sido nuestro peor momento juntos?",
+  "¿Qué cambiarías de nuestra relación?",
+  "¿Qué es lo más raro que te gusta de mí?",
+  "¿Alguna vez has revisado mi celular a escondidas?",
+  "¿Qué no sabes de mí pero te gustaría descubrir?",
+  "¿Qué mentira me has dicho?",
+  "¿Qué momento juntos te hizo sentir más orgullos@ de nuestra relación?",
+  "Si tuvieras que describir nuestra relación con una película, ¿cuál sería y por qué?",
+  "¿Qué hábito mío te encanta pero nunca me has dicho?",
+  "¿Qué canción asocias conmigo y por qué?",
+  "Si pudieras planear nuestra cita ideal, ¿qué incluiría (detalles específicos)?",
+  "¿Qué detalle pequeño mío te parece inexplicablemente sexy?",
+  "Si nuestra relación tuviera un soundtrack, ¿qué 3 canciones no podrían faltar y por qué?",
+  "¿Qué tradición curiosa te gustaría que empezáramos juntos?",
+  "¿Qué película o serie nos describe mejor como pareja?",
+  "¿Qué outfit mío te vuelve loc@ y por qué?",
+  "Si pudieras teleportarnos a cualquier lugar ahora mismo, ¿dónde iríamos y qué haríamos?",
+  "¿Qué frase o gesto mío te derrite incluso cuando estás enojad@?",
+  "¿Qué sueño o fantasía nuestra (no sexual) te gustaría cumplir este año?",
+  "¿Qué app o red social mía revisarías si tuvieras acceso libre (y por qué)?",
+  "Si mañana despertáramos intercambiando cuerpos, ¿qué sería lo primero que harías con el mío?",
+  "¿Qué parte de mi personalidad te sorprendió gratamente cuando empezamos a salir?",
+  "Si nuestra relación fuera un meme, ¿cuál sería y por qué?",
+  "¿Qué mentira piadosa me sigues diciendo para no herir mis sentimientos?",
+  "¿Qué cosa hago cuando creo que no estás mirando que te parece adorable?",
+  "Si tuvieras que describir nuestro primer beso con un título de película, ¿cuál sería?",
+  "¿Qué hábito mío has adoptado sin darte cuenta?",
+  "¿Qué apodo me pondrías si tuvieras que usarlo frente a mis amigos?",
+  "¿Qué momento nuestro te gustaría revivir en cámara lenta?",
+  "¿Qué canción de amor odias pero finges que te gusta porque a mí me encanta?",
+  "Si solo pudiéramos tener una foto juntos para el resto de nuestra vida, ¿cuál sería y por qué?",
+  "¿Qué momento cotidiano juntos (como lavar platos o hacer mercado) te parece inexplicablemente romántico?",
+  "Si nuestra relación tuviera un aroma, ¿qué olor sería y por qué?",
+  "¿Qué cosa que hago sin pensar te hace sentir más amado/a?",
+  "¿Qué error mío has aprendido a amar porque es parte de quién soy?",
+  "Si tuvieras que describir nuestro amor con un sabor de helado, ¿cuál sería y por qué?",
+  "¿Qué rasgo de personalidad mío te resultó chocante al principio pero ahora aprecias?",
+  "¿Qué promesa de pareja hemos roto que en realidad nos benefició?",
+  "Si pudiéramos intercambiar un talento o habilidad, ¿qué te gustaría que yo aprendiera de ti?",
+  "¿Qué tradición familiar mía te gustaría incorporar a nuestra relación?",
+  "Si nuestra relación fuera un libro, ¿qué capítulo estamos viviendo ahora y cómo terminaría la historia?",
+  "¿Cuál es tu recuerdo favorito de nosotros dos?",
+  "¿Qué es lo que más te atrae físicamente de mí?",
+  "¿Hay algo de mí que cambiarías si pudieras?",
+  "¿Cuál fue el momento en que supiste que me amabas?",
+  "¿Qué es lo más sexy que he hecho sin darme cuenta?",
+  "¿Cuál es tu mayor inseguridad en nuestra relación?",
+  "¿Qué es lo que más te gusta cuando hacemos el amor?",
+  "¿Cuál es tu lugar favorito para besarme?",
+  "¿Qué me dirías si supieras que mañana no nos volvemos a ver?",
+  "¿Cuál es tu sueño más grande para nuestro futuro juntos?",
+  "¿Qué pequeño gesto mío te dice que estoy de mal humor sin que lo diga con palabras?",
+  "Si pudiéramos hacer una escapada espontánea mañana mismo sin planear nada, ¿a dónde nos iríamos?",
+  "¿Qué sueño o meta personal tuya te da miedo compartir conmigo por temor a mi reacción?",
+  "¿Qué hábito mío que al principio te parecía raro ahora extrañarías si desapareciera?",
+  "¿En qué momento sentiste que nuestra relación pasó de algo casual a algo serio?"
 ]

--- a/src/data/retos/parejas-verdad.json
+++ b/src/data/retos/parejas-verdad.json
@@ -58,5 +58,10 @@
   "Si pudiéramos hacer una escapada espontánea mañana mismo sin planear nada, ¿a dónde nos iríamos?",
   "¿Qué sueño o meta personal tuya te da miedo compartir conmigo por temor a mi reacción?",
   "¿Qué hábito mío que al principio te parecía raro ahora extrañarías si desapareciera?",
-  "¿En qué momento sentiste que nuestra relación pasó de algo casual a algo serio?"
+  "¿En qué momento sentiste que nuestra relación pasó de algo casual a algo serio?",
+  "¿Qué cosa de mí te hace reír siempre, aunque intentes ponerte serio/a?",
+  "Si tuvieras que elegir una sola palabra para describir lo que sientes cuando estamos juntos, ¿cuál sería?",
+  "¿Qué es lo más valiente que he hecho por ti que crees que no valoré lo suficiente?",
+  "¿Qué cosa de nuestra relación te sorprende que todavía te emocione después de tanto tiempo juntos?",
+  "Si pudiéramos diseñar nuestra casa ideal juntos, ¿cuál sería la habitación que más disfrutarías decorar y por qué?"
 ]

--- a/src/data/retos/picante-reto.json
+++ b/src/data/retos/picante-reto.json
@@ -1,222 +1,57 @@
 [
-  {
-    "id": 1,
-    "text": "Quítate una prenda de ropa sin usar las manos."
-  },
-  {
-    "id": 2,
-    "text": "Baila sensual frente al grupo por 30 segundos."
-  },
-  {
-    "id": 3,
-    "text": "Dale un mordisco suave en el cuello a alguien del grupo."
-  },
-  {
-    "id": 4,
-    "text": "Susurra algo provocativo al oído de la persona a tu derecha."
-  },
-  {
-    "id": 5,
-    "text": "Deja que alguien te haga un chupetón en el brazo."
-  },
-  {
-    "id": 6,
-    "text": "Muerde sensualemente un alimento frente al grupo."
-  },
-  {
-    "id": 7,
-    "text": "Haz una mirada seductora a alguien del grupo."
-  },
-  {
-    "id": 8,
-    "text": "Acaricia el brazo de alguien del grupo lentamente."
-  },
-  {
-    "id": 9,
-    "text": "Di un piropo picante sin reírte."
-  },
-  {
-    "id": 10,
-    "text": "Pon hielo en tu boca y bésale el cuello a alguien."
-  },
-  {
-    "id": 11,
-    "text": "Coloca un cubo de hielo en la boca y recorre el brazo de alguien con tus labios sin usar las manos."
-  },
-  {
-    "id": 12,
-    "text": "Simula un orgasmo exagerado (sonidos incluidos) durante 10 segundos."
-  },
-  {
-    "id": 13,
-    "text": "Elige a alguien del grupo: deberás decirle al oído qué parte de su cuerpo te parece más atractiva y por qué."
-  },
-  {
-    "id": 14,
-    "text": "Con los ojos vendados, toca el cuello de una persona e intenta adivinar quién es solo por su piel."
-  },
-  {
-    "id": 15,
-    "text": "Juega a ser un/a stripper por 20 segundos (usa una chaqueta o bufanda como 'prop')."
-  },
-  {
-    "id": 16,
-    "text": "Con los ojos vendados, identifica a una persona del grupo solo tocando sus labios con un dedo."
-  },
-  {
-    "id": 17,
-    "text": "Susurra al oído de alguien una fantasía que tengas sobre esa persona (puede ser inventada)."
-  },
-  {
-    "id": 18,
-    "text": "Con una cereza en la boca (sin manos), pásasela a alguien del grupo."
-  },
-  {
-    "id": 19,
-    "text": "Escribe con miel o chocolate en el brazo de alguien una palabra provocativa y lámbela para 'borrarla'."
-  },
-  {
-    "id": 20,
-    "text": "Acaricia con una pluma o cepillo la parte más sensible del cuello de alguien (sin hablar)."
-  },
-  {
-    "id": 21,
-    "text": "Interpreta a un/a profesor/a de 'clases de seducción' dando un consejo absurdamente exagerado."
-  },
-  {
-    "id": 22,
-    "text": "Con una toalla alrededor de tu cintura, haz un striptease lento hasta quedarte con una capa de ropa normal."
-  },
-  {
-    "id": 23,
-    "text": "Dile a alguien del grupo qué olor crees que tendría su perfume ideal (ej: 'olor a playa al atardecer')."
-  },
-  {
-    "id": 24,
-    "text": "Mira fijamente a alguien mientras te pasas lentamente un cubo de hielo por los labios (10 segundos)."
-  },
-  {
-    "id": 25,
-    "text": "Elige a dos personas del grupo: una será tus 'manos' y la otra tu 'voz'. Juntos deben seducir a una tercera persona."
-  },
-  {
-    "id": 26,
-    "text": "Con una fruta entre los labios (ej: fresa), ofrécela a alguien del grupo sin usar las manos."
-  },
-  {
-    "id": 27,
-    "text": "Susurra al oído de alguien una fantasía que involucre su profesión (ej: 'si fueras mi profesor/a...')."
-  },
-  {
-    "id": 28,
-    "text": "Con los ojos vendados, identifica a una persona del grupo solo oliendo su cuello."
-  },
-  {
-    "id": 29,
-    "text": "Usando solo miradas y gestos, convence a alguien del grupo de que eres irresistible (30 segundos)."
-  },
-  {
-    "id": 30,
-    "text": "Con una pluma, dibuja un símbolo erótico en la mano de alguien mientras le susurras su significado."
-  },
-  {
-    "id": 31,
-    "text": "Interpreta a un/a masajista turco/a dando instrucciones 'sensuales' con acento exagerado."
-  },
-  {
-    "id": 32,
-    "text": "Con un cubo de hielo, recorre el contorno de los labios de alguien sin tocarlos directamente."
-  },
-  {
-    "id": 33,
-    "text": "Describe el cuerpo de alguien del grupo como si fuera una obra de arte renacentista (¡sé creativ@!)."
-  },
-  {
-    "id": 34,
-    "text": "Con una bufanda, realiza un striptease lento quitándotela en 3 movimientos exagerados."
-  },
-  {
-    "id": 35,
-    "text": "Elige a dos personas: una será tus 'ojos' (te guiará con palabras) y la otra tu 'víctima'. Deberás seducirla sin ver."
-  },
-  {
-    "id": 36,
-    "text": "Con una cereza en tu boca, ofrece el tallo a alguien para que lo jale con sus dientes (sin usar manos)"
-  },
-  {
-    "id": 37,
-    "text": "Susurra al oído de alguien qué parte de su ropa resalta mejor sus atributos (debes ser específico/a)"
-  },
-  {
-    "id": 38,
-    "text": "Con los ojos vendados, identifica a una persona solo por el tacto de sus muñecas (tienes 2 intentos)"
-  },
-  {
-    "id": 39,
-    "text": "Usando una cucharita, alimenta a alguien mientras describes el 'sabor' en voz sensual de sommelier"
-  },
-  {
-    "id": 40,
-    "text": "Con un lápiz labial, dibuja un camino de besos desde el cuello hasta la mano de alguien"
-  },
-  {
-    "id": 41,
-    "text": "Interpreta a un/a director/a de cine explicando cómo filmarías una escena de amor con alguien del grupo"
-  },
-  {
-    "id": 42,
-    "text": "Con una pluma, escribe un mensaje secreto en la espalda de alguien que otro debe descifrar al tacto"
-  },
-  {
-    "id": 43,
-    "text": "Con una toalla enrollada como cinturón, demuestra cómo quitarías imaginariamente una prenda con los dientes"
-  },
-  {
-    "id": 44,
-    "text": "Describe la personalidad de alguien usando solo comparaciones con postres sensuales (ej: 'eres como un...')"
-  },
-  {
-    "id": 45,
-    "text": "Con dos voluntarios: uno será tus ojos vendados y el otro tus manos - juntos deben seducir a una tercera persona"
-  },
-  {
-    "id": 46,
-    "text": "Haz un baile sensual usando solo movimientos de cadera por 20 segundos"
-  },
-  {
-    "id": 47,
-    "text": "Susurra al oído de alguien tu mayor fantasía sexual con esa persona"
-  },
-  {
-    "id": 48,
-    "text": "Dale un masaje sensual en los hombros a alguien del grupo por 1 minuto"
-  },
-  {
-    "id": 49,
-    "text": "Con los ojos cerrados, identifica a alguien del grupo solo por el tacto"
-  },
-  {
-    "id": 50,
-    "text": "Describe detalladamente cómo seducirías a alguien del grupo"
-  },
-  {
-    "id": 51,
-    "text": "Haz gemidos sensuales mientras comes algo dulce"
-  },
-  {
-    "id": 52,
-    "text": "Dale un beso apasionado en el cuello a alguien del grupo"
-  },
-  {
-    "id": 53,
-    "text": "Quítate lentamente una prenda de ropa mientras mantienes contacto visual con alguien"
-  },
-  {
-    "id": 54,
-    "text": "Acaricia sensualmente el brazo de alguien mientras le susurras cumplidos"
-  },
-  {
-    "id": 55,
-    "text": "Haz una demostración de cómo besas usando tu mano"
-  }
+  "Quítate una prenda de ropa sin usar las manos.",
+  "Baila sensual frente al grupo por 30 segundos.",
+  "Dale un mordisco suave en el cuello a alguien del grupo.",
+  "Susurra algo provocativo al oído de la persona a tu derecha.",
+  "Deja que alguien te haga un chupetón en el brazo.",
+  "Muerde sensualemente un alimento frente al grupo.",
+  "Haz una mirada seductora a alguien del grupo.",
+  "Acaricia el brazo de alguien del grupo lentamente.",
+  "Di un piropo picante sin reírte.",
+  "Pon hielo en tu boca y bésale el cuello a alguien.",
+  "Coloca un cubo de hielo en la boca y recorre el brazo de alguien con tus labios sin usar las manos.",
+  "Simula un orgasmo exagerado (sonidos incluidos) durante 10 segundos.",
+  "Elige a alguien del grupo: deberás decirle al oído qué parte de su cuerpo te parece más atractiva y por qué.",
+  "Con los ojos vendados, toca el cuello de una persona e intenta adivinar quién es solo por su piel.",
+  "Juega a ser un/a stripper por 20 segundos (usa una chaqueta o bufanda como 'prop').",
+  "Con los ojos vendados, identifica a una persona del grupo solo tocando sus labios con un dedo.",
+  "Susurra al oído de alguien una fantasía que tengas sobre esa persona (puede ser inventada).",
+  "Con una cereza en la boca (sin manos), pásasela a alguien del grupo.",
+  "Escribe con miel o chocolate en el brazo de alguien una palabra provocativa y lámbela para 'borrarla'.",
+  "Acaricia con una pluma o cepillo la parte más sensible del cuello de alguien (sin hablar).",
+  "Interpreta a un/a profesor/a de 'clases de seducción' dando un consejo absurdamente exagerado.",
+  "Con una toalla alrededor de tu cintura, haz un striptease lento hasta quedarte con una capa de ropa normal.",
+  "Dile a alguien del grupo qué olor crees que tendría su perfume ideal (ej: 'olor a playa al atardecer').",
+  "Mira fijamente a alguien mientras te pasas lentamente un cubo de hielo por los labios (10 segundos).",
+  "Elige a dos personas del grupo: una será tus 'manos' y la otra tu 'voz'. Juntos deben seducir a una tercera persona.",
+  "Con una fruta entre los labios (ej: fresa), ofrécela a alguien del grupo sin usar las manos.",
+  "Susurra al oído de alguien una fantasía que involucre su profesión (ej: 'si fueras mi profesor/a...').",
+  "Con los ojos vendados, identifica a una persona del grupo solo oliendo su cuello.",
+  "Usando solo miradas y gestos, convence a alguien del grupo de que eres irresistible (30 segundos).",
+  "Con una pluma, dibuja un símbolo erótico en la mano de alguien mientras le susurras su significado.",
+  "Interpreta a un/a masajista turco/a dando instrucciones 'sensuales' con acento exagerado.",
+  "Con un cubo de hielo, recorre el contorno de los labios de alguien sin tocarlos directamente.",
+  "Describe el cuerpo de alguien del grupo como si fuera una obra de arte renacentista (¡sé creativ@!).",
+  "Con una bufanda, realiza un striptease lento quitándotela en 3 movimientos exagerados.",
+  "Elige a dos personas: una será tus 'ojos' (te guiará con palabras) y la otra tu 'víctima'. Deberás seducirla sin ver.",
+  "Con una cereza en tu boca, ofrece el tallo a alguien para que lo jale con sus dientes (sin usar manos)",
+  "Susurra al oído de alguien qué parte de su ropa resalta mejor sus atributos (debes ser específico/a)",
+  "Con los ojos vendados, identifica a una persona solo por el tacto de sus muñecas (tienes 2 intentos)",
+  "Usando una cucharita, alimenta a alguien mientras describes el 'sabor' en voz sensual de sommelier",
+  "Con un lápiz labial, dibuja un camino de besos desde el cuello hasta la mano de alguien",
+  "Interpreta a un/a director/a de cine explicando cómo filmarías una escena de amor con alguien del grupo",
+  "Con una pluma, escribe un mensaje secreto en la espalda de alguien que otro debe descifrar al tacto",
+  "Con una toalla enrollada como cinturón, demuestra cómo quitarías imaginariamente una prenda con los dientes",
+  "Describe la personalidad de alguien usando solo comparaciones con postres sensuales (ej: 'eres como un...')",
+  "Con dos voluntarios: uno será tus ojos vendados y el otro tus manos - juntos deben seducir a una tercera persona",
+  "Haz un baile sensual usando solo movimientos de cadera por 20 segundos",
+  "Susurra al oído de alguien tu mayor fantasía sexual con esa persona",
+  "Dale un masaje sensual en los hombros a alguien del grupo por 1 minuto",
+  "Con los ojos cerrados, identifica a alguien del grupo solo por el tacto",
+  "Describe detalladamente cómo seducirías a alguien del grupo",
+  "Haz gemidos sensuales mientras comes algo dulce",
+  "Dale un beso apasionado en el cuello a alguien del grupo",
+  "Quítate lentamente una prenda de ropa mientras mantienes contacto visual con alguien",
+  "Acaricia sensualmente el brazo de alguien mientras le susurras cumplidos",
+  "Haz una demostración de cómo besas usando tu mano"
 ]

--- a/src/data/retos/picante-verdad.json
+++ b/src/data/retos/picante-verdad.json
@@ -1,222 +1,57 @@
 [
-  {
-    "id": 1,
-    "text": "¿Qué es lo más atrevido que has hecho en público?"
-  },
-  {
-    "id": 2,
-    "text": "¿Alguna vez has tenido un sueño erótico con alguien aquí presente?"
-  },
-  {
-    "id": 3,
-    "text": "¿Qué parte de tu cuerpo es la más sensible?"
-  },
-  {
-    "id": 4,
-    "text": "¿Qué es lo más excitante que alguien te ha dicho?"
-  },
-  {
-    "id": 5,
-    "text": "¿Dónde es el lugar más raro donde has tenido relaciones?"
-  },
-  {
-    "id": 6,
-    "text": "¿Qué fetiche tienes que nunca has confesado?"
-  },
-  {
-    "id": 7,
-    "text": "¿Qué tan seguido piensas en sexo?"
-  },
-  {
-    "id": 8,
-    "text": "¿Alguna vez has fingido un orgasmo?"
-  },
-  {
-    "id": 9,
-    "text": "¿Qué es lo más pervertido que has hecho?"
-  },
-  {
-    "id": 10,
-    "text": "¿Te gustaría hacer un trío? ¿Con quiénes?"
-  },
-  {
-    "id": 11,
-    "text": "¿Qué prenda de ropa te pone más sexy y por qué?"
-  },
-  {
-    "id": 12,
-    "text": "Si tuvieras que elegir a alguien del grupo para un role-play íntimo, ¿quién sería y qué escenario imaginarías?"
-  },
-  {
-    "id": 13,
-    "text": "¿Alguna vez has grabado o tomado fotos íntimas? ¿Las borraste o aún existen..."
-  },
-  {
-    "id": 14,
-    "text": "¿Qué juguete sexual has usado o te gustaría probar?"
-  },
-  {
-    "id": 15,
-    "text": "Describe el lugar más inusual donde te has masturbado."
-  },
-  {
-    "id": 16,
-    "text": "¿Qué fantasía sexual has tenido que nunca te atreviste a compartir con nadie?"
-  },
-  {
-    "id": 17,
-    "text": "Si tuvieras que elegir un lugar público para tener relaciones, ¿dónde sería y por qué?"
-  },
-  {
-    "id": 18,
-    "text": "¿Qué parte del cuerpo de alguien del grupo te resulta más atractiva y por qué?"
-  },
-  {
-    "id": 19,
-    "text": "¿Alguna vez has tenido un encuentro sexual que terminó siendo cómico? Cuenta los detalles."
-  },
-  {
-    "id": 20,
-    "text": "¿Qué tipo de ropa interior te pones cuando quieres sentirte sexy?"
-  },
-  {
-    "id": 21,
-    "text": "¿Cuál es tu posición favorita y qué le cambiarías para hacerla más interesante?"
-  },
-  {
-    "id": 22,
-    "text": "¿Qué sonido o gemido te excita particularmente?"
-  },
-  {
-    "id": 23,
-    "text": "Si pudieras tener una noche íntima con un personaje ficticio, ¿quién sería y qué harían?"
-  },
-  {
-    "id": 24,
-    "text": "¿Qué es lo más arriesgado que has hecho por excitación?"
-  },
-  {
-    "id": 25,
-    "text": "¿Prefieres ser dominante o sumiso/a? ¿O alternar según el momento?"
-  },
-  {
-    "id": 26,
-    "text": "¿Qué juguete sexual te genera más curiosidad y por qué nunca lo has probado?"
-  },
-  {
-    "id": 27,
-    "text": "Describe el escenario más erótico que hayas imaginado (pero no hayas vivido)."
-  },
-  {
-    "id": 28,
-    "text": "¿Qué parte de tu cuerpo te gustaría que más personas admiraran?"
-  },
-  {
-    "id": 29,
-    "text": "¿Alguna vez has tenido fantasías con alguien que no deberías? ¿De quién se trataba?"
-  },
-  {
-    "id": 30,
-    "text": "¿Qué prenda de ropa te excita más ver en otra persona y por qué?"
-  },
-  {
-    "id": 31,
-    "text": "Si tuvieras que elegir un lugar exótico para un encuentro íntimo, ¿dónde sería y qué lo haría especial?"
-  },
-  {
-    "id": 32,
-    "text": "¿Qué actitud o gesto te vuelve loc@ instantáneamente?"
-  },
-  {
-    "id": 33,
-    "text": "¿Qué película o escena te ha excitado más de lo que admitirías?"
-  },
-  {
-    "id": 34,
-    "text": "Si pudieras diseñar tu propia lencería ideal, ¿cómo sería y qué tendría de especial?"
-  },
-  {
-    "id": 35,
-    "text": "¿Qué rumor sexual sobre ti te gustaría que fuera cierto?"
-  },
-  {
-    "id": 36,
-    "text": "¿Qué prenda de vestir ajena te excitaría encontrar en tu habitación y por qué?"
-  },
-  {
-    "id": 37,
-    "text": "Si tuvieras que recrear una escena histórica con connotaciones sexuales, ¿cuál sería y qué rol tomarías?"
-  },
-  {
-    "id": 38,
-    "text": "¿Qué experiencia sensual te gustaría tener con alguien que no sea tu pareja (famoso, personaje, etc.)?"
-  },
-  {
-    "id": 39,
-    "text": "¿Qué parte de tu cuerpo te avergüenza que te excite tanto cuando la tocan?"
-  },
-  {
-    "id": 40,
-    "text": "Si pudieras añadir un nuevo sentido al placer sexual, ¿cuál sería y cómo funcionaría?"
-  },
-  {
-    "id": 41,
-    "text": "¿Qué objeto no sexual has usado con fines eróticos y cómo funcionó?"
-  },
-  {
-    "id": 42,
-    "text": "¿Qué situación social normal (ej: reunión de trabajo) has fantaseado convertir en íntima?"
-  },
-  {
-    "id": 43,
-    "text": "Si tuvieras un super poder sexual, ¿cuál sería y qué limitación cómica tendría?"
-  },
-  {
-    "id": 44,
-    "text": "¿Qué juguete sexual inventarías y cómo se usaría?"
-  },
-  {
-    "id": 45,
-    "text": "Si tu vida sexual fuera una serie de Netflix, ¿qué título tendría y cuál sería el plot twist de la temporada 2?"
-  },
-  {
-    "id": 46,
-    "text": "¿Con cuántas personas has tenido relaciones sexuales?"
-  },
-  {
-    "id": 47,
-    "text": "¿Cuál es tu zona erógena más sensible?"
-  },
-  {
-    "id": 48,
-    "text": "¿Qué es lo más excitante que te han hecho en la cama?"
-  },
-  {
-    "id": 49,
-    "text": "¿Alguna vez has tenido un encuentro sexual de una noche?"
-  },
-  {
-    "id": 50,
-    "text": "¿Cuál es tu fantasía sexual más salvaje?"
-  },
-  {
-    "id": 51,
-    "text": "¿Qué parte del cuerpo de alguien aquí presente te atrae más?"
-  },
-  {
-    "id": 52,
-    "text": "¿Cuál ha sido tu experiencia sexual más intensa?"
-  },
-  {
-    "id": 53,
-    "text": "¿Qué te excita más: dominar o ser dominado?"
-  },
-  {
-    "id": 54,
-    "text": "¿Cuál es el lugar más atrevido donde has tenido relaciones?"
-  },
-  {
-    "id": 55,
-    "text": "¿Qué es lo más pervertido que has pensado hacer pero nunca te has atrevido?"
-  }
+  "¿Qué es lo más atrevido que has hecho en público?",
+  "¿Alguna vez has tenido un sueño erótico con alguien aquí presente?",
+  "¿Qué parte de tu cuerpo es la más sensible?",
+  "¿Qué es lo más excitante que alguien te ha dicho?",
+  "¿Dónde es el lugar más raro donde has tenido relaciones?",
+  "¿Qué fetiche tienes que nunca has confesado?",
+  "¿Qué tan seguido piensas en sexo?",
+  "¿Alguna vez has fingido un orgasmo?",
+  "¿Qué es lo más pervertido que has hecho?",
+  "¿Te gustaría hacer un trío? ¿Con quiénes?",
+  "¿Qué prenda de ropa te pone más sexy y por qué?",
+  "Si tuvieras que elegir a alguien del grupo para un role-play íntimo, ¿quién sería y qué escenario imaginarías?",
+  "¿Alguna vez has grabado o tomado fotos íntimas? ¿Las borraste o aún existen...",
+  "¿Qué juguete sexual has usado o te gustaría probar?",
+  "Describe el lugar más inusual donde te has masturbado.",
+  "¿Qué fantasía sexual has tenido que nunca te atreviste a compartir con nadie?",
+  "Si tuvieras que elegir un lugar público para tener relaciones, ¿dónde sería y por qué?",
+  "¿Qué parte del cuerpo de alguien del grupo te resulta más atractiva y por qué?",
+  "¿Alguna vez has tenido un encuentro sexual que terminó siendo cómico? Cuenta los detalles.",
+  "¿Qué tipo de ropa interior te pones cuando quieres sentirte sexy?",
+  "¿Cuál es tu posición favorita y qué le cambiarías para hacerla más interesante?",
+  "¿Qué sonido o gemido te excita particularmente?",
+  "Si pudieras tener una noche íntima con un personaje ficticio, ¿quién sería y qué harían?",
+  "¿Qué es lo más arriesgado que has hecho por excitación?",
+  "¿Prefieres ser dominante o sumiso/a? ¿O alternar según el momento?",
+  "¿Qué juguete sexual te genera más curiosidad y por qué nunca lo has probado?",
+  "Describe el escenario más erótico que hayas imaginado (pero no hayas vivido).",
+  "¿Qué parte de tu cuerpo te gustaría que más personas admiraran?",
+  "¿Alguna vez has tenido fantasías con alguien que no deberías? ¿De quién se trataba?",
+  "¿Qué prenda de ropa te excita más ver en otra persona y por qué?",
+  "Si tuvieras que elegir un lugar exótico para un encuentro íntimo, ¿dónde sería y qué lo haría especial?",
+  "¿Qué actitud o gesto te vuelve loc@ instantáneamente?",
+  "¿Qué película o escena te ha excitado más de lo que admitirías?",
+  "Si pudieras diseñar tu propia lencería ideal, ¿cómo sería y qué tendría de especial?",
+  "¿Qué rumor sexual sobre ti te gustaría que fuera cierto?",
+  "¿Qué prenda de vestir ajena te excitaría encontrar en tu habitación y por qué?",
+  "Si tuvieras que recrear una escena histórica con connotaciones sexuales, ¿cuál sería y qué rol tomarías?",
+  "¿Qué experiencia sensual te gustaría tener con alguien que no sea tu pareja (famoso, personaje, etc.)?",
+  "¿Qué parte de tu cuerpo te avergüenza que te excite tanto cuando la tocan?",
+  "Si pudieras añadir un nuevo sentido al placer sexual, ¿cuál sería y cómo funcionaría?",
+  "¿Qué objeto no sexual has usado con fines eróticos y cómo funcionó?",
+  "¿Qué situación social normal (ej: reunión de trabajo) has fantaseado convertir en íntima?",
+  "Si tuvieras un super poder sexual, ¿cuál sería y qué limitación cómica tendría?",
+  "¿Qué juguete sexual inventarías y cómo se usaría?",
+  "Si tu vida sexual fuera una serie de Netflix, ¿qué título tendría y cuál sería el plot twist de la temporada 2?",
+  "¿Con cuántas personas has tenido relaciones sexuales?",
+  "¿Cuál es tu zona erógena más sensible?",
+  "¿Qué es lo más excitante que te han hecho en la cama?",
+  "¿Alguna vez has tenido un encuentro sexual de una noche?",
+  "¿Cuál es tu fantasía sexual más salvaje?",
+  "¿Qué parte del cuerpo de alguien aquí presente te atrae más?",
+  "¿Cuál ha sido tu experiencia sexual más intensa?",
+  "¿Qué te excita más: dominar o ser dominado?",
+  "¿Cuál es el lugar más atrevido donde has tenido relaciones?",
+  "¿Qué es lo más pervertido que has pensado hacer pero nunca te has atrevido?"
 ]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,6 @@
 import { ImageSourcePropType } from "react-native";
 
 export interface Reto {
-  id: number;
   type: "verdad" | "reto";
   text: string;
 }

--- a/src/utils/getRandomReto.ts
+++ b/src/utils/getRandomReto.ts
@@ -1,6 +1,6 @@
 import { Reto } from "../types";
 
-const data: Record<string, Reto[]> = {
+const data: Record<string, string[]> = {
   "clasico-verdad": require("../data/retos/clasico-verdad.json"),
   "clasico-reto": require("../data/retos/clasico-reto.json"),
   "picante-verdad": require("../data/retos/picante-verdad.json"),
@@ -37,5 +37,5 @@ export function getRandomReto(
   usados.add(index);
   usadosPorCategoria[`${categoria}-${type}`] = usados;
 
-  return { ...retos[index], type };
+  return { text: retos[index], type };
 }


### PR DESCRIPTION
## Summary
- Convert all 12 JSON question files from `[{id, text}]` objects to flat `string[]` arrays — removes the `id` field that was never used by the app logic (`getRandomReto.ts` tracks seen questions by array index, not id)
- Bundle size drops **~27 KB** (87.6 KB → 60.6 KB total across all question files)
- Update `Reto` interface in `src/types/index.ts` (remove `id: number`)
- Update `getRandomReto.ts` to use `string[]` and return `{ text: retos[index], type }`
- Add 5 new questions to each of 4 verdad files (+20 total):
  - `clasico-verdad`: 60 → 65 questions
  - `parejas-verdad`: 55 → 60 questions
  - `amigos-verdad`: 60 → 65 questions
  - `chicas-verdad`: 60 → 65 questions

## Test plan
- [ ] Open app and navigate to each category (Clásico, Parejas, Amigos, Chicas)
- [ ] Confirm verdad questions appear and rotate without repetition
- [ ] Confirm reto questions still work (all 6 reto files were also converted)
- [ ] Check that no TypeScript errors appear at build time

🤖 Generated with [Claude Code](https://claude.com/claude-code)