### PR TITLE
perf: optimize CategoryScreen hooks and handlers

### DIFF
--- a/src/screens/CategoryScreen.tsx
+++ b/src/screens/CategoryScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { StyleSheet, ImageBackground, ScrollView } from "react-native";
 import {
   RewardedAd,
@@ -34,20 +34,14 @@ export default function CategoryScreen({ navigation }: Props) {
   const [isChicasUnlocked, setIsChicasUnlocked] = useState<boolean>(false);
   const [loadedChicas, setLoadedChicas] = useState(false);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     const unlocked = await isUnlocked();
     setIsCategoryUnlocked(unlocked);
     const chicasUnlocked = await isUnlockedChicas();
     setIsChicasUnlocked(chicasUnlocked);
-  };
-
-  useEffect(() => {
-    load();
   }, []);
 
-  useFocusEffect(() => {
-    load();
-  });
+  useFocusEffect(load);
 
   const onPressItem = useCallback(
     (id: string) => {
@@ -56,13 +50,19 @@ export default function CategoryScreen({ navigation }: Props) {
     [navigation],
   );
 
-  const onPressExtremo = (id: string) => {
-    isCategoryUnlocked ? onPressItem(id) : setIsModalVisible(true);
-  };
+  const onPressExtremo = useCallback(
+    (id: string) => {
+      isCategoryUnlocked ? onPressItem(id) : setIsModalVisible(true);
+    },
+    [isCategoryUnlocked, onPressItem],
+  );
 
-  const onPressChicas = (id: string) => {
-    isChicasUnlocked ? onPressItem(id) : setIsChicasModalVisible(true);
-  };
+  const onPressChicas = useCallback(
+    (id: string) => {
+      isChicasUnlocked ? onPressItem(id) : setIsChicasModalVisible(true);
+    },
+    [isChicasUnlocked, onPressItem],
+  );
 
   useEffect(() => {
     const unsubscribeLoaded = rewarded.addAdEventListener(


### PR DESCRIPTION
## Summary
- **Fix `useFocusEffect` bug**: estaba sin `useCallback`, por lo que se ejecutaba en cada render en lugar de solo al enfocar la pantalla — llamando a `isUnlocked()` e `isUnlockedChicas()` (lecturas de AsyncStorage) innecesariamente con cada cambio de estado
- **Eliminar `useEffect` duplicado**: `useFocusEffect` ya cubre el mount inicial, el `useEffect(() => load(), [])` adicional causaba una doble lectura de storage al abrir la pantalla
- **Memoizar `onPressExtremo` y `onPressChicas`** con `useCallback` para evitar pasar nuevas referencias a `CategoryButton` en cada render
- Eliminar import `useMemo` sin usar

## Test plan
- [ ] Abrir la pantalla de categorías y verificar que las categorías bloqueadas/desbloqueadas se muestran correctamente
- [ ] Verificar que el unlock de Extremo y Chicas sigue funcionando tras ver el rewarded ad
- [ ] Confirmar que al volver a la pantalla (desde el juego) el estado de unlock se refresca correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)